### PR TITLE
[BOUNTY #5905] Health Dashboard

### DIFF
--- a/src/health-dashboard.ts
+++ b/src/health-dashboard.ts
@@ -1,0 +1,234 @@
+/**
+ * Health Dashboard for UBQ.FI
+ * Checks availability of all apps and plugins.
+ */
+
+const APP_SUBDOMAINS = ["pay", "work", "dashboard", "docs"] as const;
+const GITHUB_API = "https://api.github.com";
+const HEALTH_CHECK_TIMEOUT = 5000; // 5s per check
+
+interface HealthEntry {
+  name: string
+  url: string
+  type: "app" | "plugin"
+  status: "healthy" | "degraded" | "unhealthy" | "unknown"
+  responseTime?: number
+  statusCode?: number
+  error?: string
+  checkedAt: string
+}
+
+interface HealthDashboard {
+  version: string
+  generated: string
+  generator: string
+  summary: {
+    total: number
+    healthy: number
+    degraded: number
+    unhealthy: number
+    unknown: number
+  }
+  apps: HealthEntry[]
+  plugins: HealthEntry[]
+}
+
+async function checkUrl(url: string, timeout = HEALTH_CHECK_TIMEOUT): Promise<{
+  status: "healthy" | "degraded" | "unhealthy"
+  responseTime: number
+  statusCode: number
+}> {
+  const start = Date.now();
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeout),
+      headers: { "User-Agent": "ubq-fi-health-check" },
+    });
+    const responseTime = Date.now() - start;
+    const statusCode = res.status;
+
+    if (statusCode >= 200 && statusCode < 400) {
+      return { status: "healthy", responseTime, statusCode };
+    } else if (statusCode >= 400 && statusCode < 500) {
+      // 4xx might mean the app is up but the specific path doesn't exist
+      return { status: "degraded", responseTime, statusCode };
+    } else {
+      return { status: "unhealthy", responseTime, statusCode };
+    }
+  } catch (err) {
+    const responseTime = Date.now() - start;
+    return {
+      status: "unhealthy",
+      responseTime,
+      statusCode: 0,
+    };
+  }
+}
+
+async function fetchPluginRepos(): Promise<string[]> {
+  try {
+    const res = await fetch(`${GITHUB_API}/orgs/ubiquity-os-marketplace/repos?per_page=100&sort=updated`, {
+      headers: { Accept: "application/vnd.github.v3+json", "User-Agent": "ubq-fi-health" },
+    });
+    if (!res.ok) return [];
+    const repos: Array<{ name: string }> = await res.json();
+    return repos
+      .filter((r) => !r.name.startsWith(".") && !["command-config"].includes(r.name))
+      .map((r) => r.name);
+  } catch {
+    return [];
+  }
+}
+
+async function checkHealth(): Promise<HealthDashboard> {
+  const now = new Date().toISOString();
+
+  // Check apps
+  const appEntries: HealthEntry[] = await Promise.all(
+    APP_SUBDOMAINS.map(async (sub) => {
+      const url = `https://${sub}.ubq.fi`;
+      const result = await checkUrl(url);
+      return {
+        name: sub,
+        url,
+        type: "app" as const,
+        ...result,
+        checkedAt: now,
+      };
+    })
+  );
+
+  // Check plugins
+  const pluginNames = await fetchPluginRepos();
+  const pluginEntries: HealthEntry[] = await Promise.all(
+    pluginNames.map(async (name) => {
+      const url = `https://os-${name}.ubq.fi`;
+      const result = await checkUrl(url);
+      return {
+        name,
+        url,
+        type: "plugin" as const,
+        ...result,
+        checkedAt: now,
+      };
+    })
+  );
+
+  const all = [...appEntries, ...pluginEntries];
+  const summary = {
+    total: all.length,
+    healthy: all.filter((e) => e.status === "healthy").length,
+    degraded: all.filter((e) => e.status === "degraded").length,
+    unhealthy: all.filter((e) => e.status === "unhealthy").length,
+    unknown: all.filter((e) => e.status === "unknown").length,
+  };
+
+  return {
+    version: "1.0.0",
+    generated: now,
+    generator: "ubq-fi-router",
+    summary,
+    apps: appEntries,
+    plugins: pluginEntries,
+  };
+}
+
+function renderHtmlDashboard(data: HealthDashboard): string {
+  const { summary, apps, plugins } = data;
+
+  const statusIcon = (s: string) => {
+    switch (s) {
+      case "healthy":
+        return "🟢";
+      case "degraded":
+        return "🟡";
+      case "unhealthy":
+        return "🔴";
+      default:
+        return "⚪";
+    }
+  };
+
+  const formatTime = (ms?: number) => (ms !== undefined ? `${ms}ms` : "—");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>UBQ.FI Health Dashboard</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0d1117; color: #c9d1d9; padding: 2rem; }
+    h1 { color: #58a6ff; margin-bottom: 0.5rem; font-size: 1.5rem; }
+    .subtitle { color: #8b949e; margin-bottom: 1.5rem; font-size: 0.875rem; }
+    .summary { display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap; }
+    .summary-card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 1rem 1.5rem; min-width: 120px; }
+    .summary-card .value { font-size: 2rem; font-weight: 700; }
+    .summary-card .label { color: #8b949e; font-size: 0.75rem; margin-top: 0.25rem; }
+    .healthy .value { color: #3fb950; }
+    .degraded .value { color: #d29922; }
+    .unhealthy .value { color: #f85149; }
+    .total .value { color: #58a6ff; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 2rem; }
+    th, td { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid #21262d; }
+    th { color: #8b949e; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    td { font-size: 0.875rem; }
+    a { color: #58a6ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .status { display: inline-flex; align-items: center; gap: 0.5rem; }
+    .badge { padding: 0.15rem 0.5rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 600; }
+    .badge-healthy { background: #0d2818; color: #3fb950; }
+    .badge-degraded { background: #2d2000; color: #d29922; }
+    .badge-unhealthy { background: #2d0b0b; color: #f85149; }
+    .badge-unknown { background: #1c1c1c; color: #8b949e; }
+    section h2 { color: #c9d1d9; font-size: 1.1rem; margin-bottom: 0.75rem; }
+    .generated { color: #484f58; font-size: 0.75rem; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>🏥 UBQ.FI Health Dashboard</h1>
+  <p class="subtitle">Real-time status of all apps and plugins</p>
+
+  <div class="summary">
+    <div class="summary-card total"><div class="value">${summary.total}</div><div class="label">Total Services</div></div>
+    <div class="summary-card healthy"><div class="value">${summary.healthy}</div><div class="label">Healthy</div></div>
+    <div class="summary-card degraded"><div class="value">${summary.degraded}</div><div class="label">Degraded</div></div>
+    <div class="summary-card unhealthy"><div class="value">${summary.unhealthy}</div><div class="label">Unhealthy</div></div>
+  </div>
+
+  <section>
+    <h2>Apps</h2>
+    <table>
+      <tr><th>Status</th><th>Name</th><th>Response</th><th>HTTP</th></tr>
+      ${apps.map((a) => `<tr>
+        <td><span class="status">${statusIcon(a.status)} <span class="badge badge-${a.status}">${a.status}</span></span></td>
+        <td><a href="${a.url}" target="_blank">${a.name}</a></td>
+        <td>${formatTime(a.responseTime)}</td>
+        <td>${a.statusCode || "—"}</td>
+      </tr>`).join("")}
+    </table>
+  </section>
+
+  <section>
+    <h2>Plugins (${plugins.length})</h2>
+    <table>
+      <tr><th>Status</th><th>Name</th><th>Response</th><th>HTTP</th></tr>
+      ${plugins.map((p) => `<tr>
+        <td><span class="status">${statusIcon(p.status)} <span class="badge badge-${p.status}">${p.status}</span></span></td>
+        <td><a href="${p.url}" target="_blank">${p.name}</a></td>
+        <td>${formatTime(p.responseTime)}</td>
+        <td>${p.statusCode || "—"}</td>
+      </tr>`).join("")}
+    </table>
+  </section>
+
+  <p class="generated">Generated: ${data.generated} • <a href="/health.json">JSON API</a> • <a href="/health-history">History</a></p>
+</body>
+</html>`;
+}
+
+export { checkHealth, renderHtmlDashboard };
+export type { HealthDashboard, HealthEntry };

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -1,0 +1,125 @@
+/**
+ * Sitemap generator for UBQ.FI
+ * Produces XML sitemap and JSON index of all known apps and plugins.
+ */
+
+const APP_SUBDOMAINS = [
+  "",
+  "www",
+  "pay",
+  "work",
+  "dashboard",
+  "docs",
+] as const;
+
+const GITHUB_API = "https://api.github.com";
+const UBQ_FI_BASE = "https://ubq.fi";
+
+interface SitemapEntry {
+  loc: string
+  changefreq?: "daily" | "weekly" | "monthly"
+  priority: number
+  lastmod?: string
+}
+
+interface JsonSitemap {
+  version: string
+  generated: string
+  generator: string
+  base_url: string
+  apps: SitemapEntry[]
+  plugins: SitemapEntry[]
+  total: number
+}
+
+/**
+ * Get all plugin repositories from the ubiquity-os-marketplace GitHub org
+ */
+async function fetchPluginRepos(): Promise<string[]> {
+  const res = await fetch(`${GITHUB_API}/orgs/ubiquity-os-marketplace/repos?per_page=100&sort=updated`, {
+    headers: {
+      "Accept": "application/vnd.github.v3+json",
+      "User-Agent": "ubq-fi-sitemap-generator",
+    },
+  });
+
+  if (!res.ok) {
+    console.error(`Failed to fetch plugin repos: ${res.status}`);
+    return [];
+  }
+
+  const repos: Array<{ name: string; pushed_at: string }> = await res.json();
+
+  // Skip non-plugin repos (config repos, .github, etc.)
+  return repos
+    .filter((r) => !r.name.startsWith(".") && !["command-config", "command-wallet", "command-query", "daemon-pricing", "daemon-merging", "daemon-disqualifier", "daemon-task-matcher", "daemon-planner", "daemon-xp", "daemon-spec-rewriter", "daemon-xp"].includes(r.name))
+    .map((r) => r.name);
+}
+
+/**
+ * Generate XML sitemap string
+ */
+function toXmlSitemap(entries: SitemapEntry[]): string {
+  const urls = entries
+    .map(
+      (e) => `  <url>
+    <loc>${escapeXml(e.loc)}</loc>${e.lastmod ? `\n    <lastmod>${e.lastmod}</lastmod>` : ""}${e.changefreq ? `\n    <changefreq>${e.changefreq}</changefreq>` : ""}${e.priority !== undefined ? `\n    <priority>${e.priority.toFixed(1)}</priority>` : ""}
+  </url>`
+    )
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`;
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Build the full sitemap (apps + plugins)
+ */
+export async function buildSitemap(): Promise<{ xml: string; json: JsonSitemap }> {
+  const now = new Date().toISOString();
+  const appEntries: SitemapEntry[] = APP_SUBDOMAINS.map((sub) => ({
+    loc: sub ? `https://${sub}.ubq.fi` : UBQ_FI_BASE,
+    changefreq: "daily" as const,
+    priority: sub === "" || sub === "www" ? 1.0 : 0.8,
+  }));
+
+  let pluginEntries: SitemapEntry[] = [];
+
+  try {
+    const pluginNames = await fetchPluginRepos();
+    pluginEntries = pluginNames.map((name, i) => ({
+      loc: `https://os-${name}.ubq.fi`,
+      changefreq: "weekly" as const,
+      priority: 0.6,
+    }));
+  } catch (err) {
+    console.error("Failed to build plugin sitemap entries:", err);
+  }
+
+  const allEntries = [...appEntries, ...pluginEntries];
+  const jsonSitemap: JsonSitemap = {
+    version: "1.0.0",
+    generated: now,
+    generator: "ubq-fi-router",
+    base_url: UBQ_FI_BASE,
+    apps: appEntries,
+    plugins: pluginEntries,
+    total: allEntries.length,
+  };
+
+  return {
+    xml: toXmlSitemap(allEntries),
+    json: jsonSitemap,
+  };
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,6 +9,7 @@ import { isPluginDomain } from './utils/is-plugin-domain'
 import { buildDenoUrl } from './utils/build-deno-url'
 import { buildPluginUrl } from './utils/build-plugin-url'
 import { buildSitemap } from './sitemap'
+import { checkHealth, renderHtmlDashboard } from './health-dashboard'
 
 export interface Env {
   // Optional env vars to control logging without code changes
@@ -68,6 +69,11 @@ export default {
     // Sitemap endpoints
     if (url.pathname === '/sitemap.xml' || url.pathname === '/sitemap.json') {
       return handleSitemap(url.pathname)
+    }
+
+    // Health dashboard endpoints
+    if (url.pathname === '/health-dashboard' || url.pathname === '/health-dashboard.html' || url.pathname === '/health.json') {
+      return handleHealthDashboard(url.pathname)
     }
 
     if (url.pathname.startsWith('/rpc/')) {
@@ -258,5 +264,30 @@ async function handleSitemap(pathname: string): Promise<Response> {
   } catch (err) {
     console.error('Sitemap generation failed:', err)
     return new Response('Sitemap generation error', { status: 500 })
+  }
+}
+
+async function handleHealthDashboard(pathname: string): Promise<Response> {
+  try {
+    const data = await checkHealth()
+    if (pathname === '/health.json') {
+      return new Response(JSON.stringify(data, null, 2), {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+        },
+      })
+    } else {
+      const html = renderHtmlDashboard(data)
+      return new Response(html, {
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control': 'no-store',
+        },
+      })
+    }
+  } catch (err) {
+    console.error('Health dashboard failed:', err)
+    return new Response('Health dashboard error', { status: 500 })
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,6 +8,7 @@ import { getSubdomainKey } from './utils/get-subdomain-key'
 import { isPluginDomain } from './utils/is-plugin-domain'
 import { buildDenoUrl } from './utils/build-deno-url'
 import { buildPluginUrl } from './utils/build-plugin-url'
+import { buildSitemap } from './sitemap'
 
 export interface Env {
   // Optional env vars to control logging without code changes
@@ -62,6 +63,11 @@ export default {
         } catch {}
       }
       return json({ status: 'ok', time: new Date().toISOString() })
+    }
+
+    // Sitemap endpoints
+    if (url.pathname === '/sitemap.xml' || url.pathname === '/sitemap.json') {
+      return handleSitemap(url.pathname)
     }
 
     if (url.pathname.startsWith('/rpc/')) {
@@ -229,4 +235,28 @@ function shortHash(input: string): string {
     h = (h * 31 + ch.charCodeAt(0)) >>> 0
   }
   return h.toString(16).padStart(4, '0').slice(0, 4)
+}
+
+async function handleSitemap(pathname: string): Promise<Response> {
+  try {
+    const { xml, json: jsonSitemap } = await buildSitemap()
+    if (pathname === '/sitemap.xml') {
+      return new Response(xml, {
+        headers: {
+          'Content-Type': 'application/xml; charset=utf-8',
+          'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+        },
+      })
+    } else {
+      return new Response(JSON.stringify(jsonSitemap, null, 2), {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+        },
+      })
+    }
+  } catch (err) {
+    console.error('Sitemap generation failed:', err)
+    return new Response('Sitemap generation error', { status: 500 })
+  }
 }


### PR DESCRIPTION
## Summary

Real-time health dashboard for all UBQ.FI apps and plugins, built directly into the Cloudflare Worker router.

## Endpoints

| Endpoint | Type | Description |
|----------|------|-------------|
| `/health-dashboard` | HTML | Dark-themed dashboard page |
| `/health.json` | JSON | Machine-readable API |

## Features

- **Apps**: Checks pay, work, dashboard, docs subdomains
- **Plugins**: Auto-discovers from `ubiquity-os-marketplace` GitHub org
- **Status levels**: 🟢 Healthy (2xx) / 🟡 Degraded (4xx) / 🔴 Unhealthy (5xx/timeout)
- **Summary cards**: Total, healthy, degraded, unhealthy counts
- **Per-service**: Response time (ms) + HTTP status code
- **5s timeout** per health check
- **No caching** (real-time data)

## Interop

Works with the [Plugin Health Monitor](https://github.com/ubiquity-os/.github/issues/12) cron job for alerting.

Closes ubiquity/ubq.fi-router#3 (linked from devpool-directory #5905)