### PR TITLE
Route services through Deno 2 with Classic fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ bun run deploy
 - Verify URL building logic in `src/utils.ts`
 - Clear cache and refresh: `curl -H "X-Cache-Control: clear" https://domain.ubq.fi`
 
-**Cache not updating**
-- Use `X-Cache-Control: refresh` to force update
-- Check KV namespace configuration
-- Verify cache TTL settings
+**Deno 2 probe cache not updating**
+- Probe results use Cloudflare Cache, not KV.
+- Missing Deno 2 app results expire after 60 seconds.
+- Existing Deno 2 app results expire after 5 minutes.
 
 **Build failures**
 - Run `bun run type-check` for TypeScript errors

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Entry point: `src/worker.ts` (module worker).
 ## Routing Rules
 
 - Services
-- `ubq.fi` → `https://ubq-fi.deno.dev`
-- `<sub>.ubq.fi` → `https://<sub>-ubq-fi.deno.dev`
+  - `ubq.fi` → try `https://ubq-fi.ubiquity-dao.deno.net`, fall back to `https://ubq-fi.deno.dev`
+  - `<sub>.ubq.fi` → try `https://<sub>-ubq-fi.ubiquity-dao.deno.net`, fall back to `https://<sub>-ubq-fi.deno.dev`
+  - Deno 2 is considered missing only when the Deno platform returns `x-deno-error.code=DEPLOYMENT_NOT_FOUND`
+  - Deploy Classic fallback responses include deprecation headers for the July 20, 2026 Deploy Classic shutdown
 - Plugins (`os-*.ubq.fi`)
   - `os-<plugin>.ubq.fi` → `<plugin>-main.deno.dev`
   - `os-<plugin>-main.ubq.fi` → `<plugin>-main.deno.dev`
@@ -28,8 +30,10 @@ Entry point: `src/worker.ts` (module worker).
 ## Notes
 
 - Routes are managed in the Cloudflare dashboard; `wrangler.toml` does not attach routes.
-- We do not persist any state (no KV, no LKG, no admin endpoints).
+- We do not persist app state (no KV, no LKG, no admin endpoints). The Worker uses short-lived Cloudflare Cache entries for Deno 2 existence probes.
 - Upstream headers/status are passed through; we strip host/origin/referer/cookie to upstream.
+- Deploy Classic fallback responses include `Deprecation`, `Sunset`, `Warning`, and `X-UOS-Deno-Classic-*` headers.
+- If both the Deno 2 app and Deploy Classic fallback are missing, the Worker returns a JSON `503` explaining that Deploy Classic is sunsetted and the service must be migrated.
 
 
 ## 🔧 Development Workflow
@@ -72,16 +76,16 @@ bun run deploy
   - `event: "route_error"` on upstream failures
   - `event: "health"` for `GET /__health`
 
-### KV Cache Inspection
-Check your Cloudflare KV namespace for cache entries:
-- Keys follow pattern: `route:{subdomain}`
-- Values: `"deno"`, `"pages"`, `"both"`, `"plugin"`, or `"none"`
+### Deno 2 Probe Cache
+- Positive Deno 2 probe results are cached for 5 minutes.
+- Missing Deno 2 app results are cached for 60 seconds.
+- Probe errors are not cached and fall back to Deploy Classic for that request.
 
 ### Performance Metrics
 - **Bundle Size**: ~4.6kb (optimized)
-- **Cache TTL**: 1 hour (success), 5 minutes (404)
-- **Timeout**: 3 seconds per service check
-- **Coalescing**: Prevents duplicate requests
+- **Probe Cache TTL**: 5 minutes for Deno 2 apps, 60 seconds for missing Deno 2 apps
+- **Probe Timeout**: 1.5 seconds
+- **Proxy Timeout**: 6 seconds
 
 ## 🔍 Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cf:deploy": "wrangler deploy",
     "type-check": "tsc --noEmit",
     "build": "mkdir -p dist && cp src/worker.ts dist/worker.js",
-    "test": "echo 'No tests defined yet'"
+    "test": "bun test"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/src/utils/build-deno-url.ts
+++ b/src/utils/build-deno-url.ts
@@ -1,10 +1,164 @@
-/**
- * Build Deno deployment URL
- */
-export function buildDenoUrl(subdomain: string, url: URL): string {
+const DENO_ORG_SLUG = 'ubiquity-dao'
+const DENO2_POSITIVE_CACHE_SECONDS = 300
+const DENO2_NEGATIVE_CACHE_SECONDS = 60
+const DENO2_PROBE_TIMEOUT_MS = 1500
+
+export const DENO_CLASSIC_SUNSET_DATE = '2026-07-20'
+export const DENO_CLASSIC_SUNSET_HTTP_DATE = 'Mon, 20 Jul 2026 00:00:00 GMT'
+export const DENO_CLASSIC_MIGRATION_URL = 'https://docs.deno.com/deploy/migration_guide/'
+export const DENO_CLASSIC_FALLBACK_WARNING =
+  `Deno Deploy Classic fallback in use; migrate this service to Deno Deploy before ${DENO_CLASSIC_SUNSET_DATE}.`
+
+export type DenoRouteTarget = Readonly<{
+  url: string
+  kind: 'deno2' | 'classic'
+  deno2Url: string
+  classicUrl: string
+  fallbackReason?: 'deno2_deployment_not_found' | 'deno2_probe_failed'
+}>
+
+type ProbeResult = true | false | null
+type CacheLike = Pick<Cache, 'match' | 'put'>
+type ProbeFetch = (input: string, init?: RequestInit) => Promise<Response>
+
+export type ResolveDenoUrlOptions = Readonly<{
+  cache?: CacheLike | null
+  fetch?: ProbeFetch
+  probeTimeoutMs?: number
+}>
+
+export function buildDeno2AppSlug(subdomain: string): string {
+  return subdomain === '' ? 'ubq-fi' : `${subdomain}-ubq-fi`
+}
+
+export function buildDeno2Url(subdomain: string, url: URL): string {
+  return `https://${buildDeno2AppSlug(subdomain)}.${DENO_ORG_SLUG}.deno.net${url.pathname}${url.search}`
+}
+
+export function buildClassicDenoUrl(subdomain: string, url: URL): string {
   if (subdomain === '') {
     return `https://ubq-fi.deno.dev${url.pathname}${url.search}`
-  } else {
-    return `https://${subdomain}-ubq-fi.deno.dev${url.pathname}${url.search}`
+  }
+  return `https://${subdomain}-ubq-fi.deno.dev${url.pathname}${url.search}`
+}
+
+export const buildDenoUrl = buildClassicDenoUrl
+
+export async function resolveDenoUrl(
+  subdomain: string,
+  url: URL,
+  options: ResolveDenoUrlOptions = {},
+): Promise<DenoRouteTarget> {
+  const deno2Url = buildDeno2Url(subdomain, url)
+  const classicUrl = buildClassicDenoUrl(subdomain, url)
+  const deno2Exists = await deno2DeploymentExists(subdomain, options)
+
+  if (deno2Exists) {
+    return { url: deno2Url, kind: 'deno2', deno2Url, classicUrl }
+  }
+
+  return {
+    url: classicUrl,
+    kind: 'classic',
+    deno2Url,
+    classicUrl,
+    fallbackReason: deno2Exists === false ? 'deno2_deployment_not_found' : 'deno2_probe_failed',
+  }
+}
+
+export function isDenoDeploymentNotFound(headers: Headers): boolean {
+  const raw = headers.get('x-deno-error')
+  if (!raw) return false
+
+  try {
+    const parsed = JSON.parse(raw) as { code?: unknown }
+    return parsed.code === 'DEPLOYMENT_NOT_FOUND'
+  } catch {
+    return raw.includes('DEPLOYMENT_NOT_FOUND')
+  }
+}
+
+async function deno2DeploymentExists(
+  subdomain: string,
+  options: ResolveDenoUrlOptions,
+): Promise<ProbeResult> {
+  const appSlug = buildDeno2AppSlug(subdomain)
+  const cache = options.cache ?? getDefaultCache()
+  const cached = await readProbeCache(cache, appSlug)
+  if (cached !== null) return cached
+
+  const result = await probeDeno2Deployment(appSlug, options)
+  if (result !== null) {
+    await writeProbeCache(cache, appSlug, result)
+  }
+  return result
+}
+
+async function probeDeno2Deployment(
+  appSlug: string,
+  options: ResolveDenoUrlOptions,
+): Promise<ProbeResult> {
+  const fetcher = options.fetch ?? fetch
+  const probeUrl = `https://${appSlug}.${DENO_ORG_SLUG}.deno.net/__ubq_route_probe__`
+
+  try {
+    const res = await fetcher(probeUrl, {
+      method: 'HEAD',
+      redirect: 'manual',
+      signal: AbortSignal.timeout(options.probeTimeoutMs ?? DENO2_PROBE_TIMEOUT_MS),
+    })
+
+    try {
+      await res.body?.cancel()
+    } catch {}
+
+    return !isDenoDeploymentNotFound(res.headers)
+  } catch {
+    return null
+  }
+}
+
+async function readProbeCache(cache: CacheLike | null, appSlug: string): Promise<ProbeResult> {
+  if (!cache) return null
+
+  try {
+    const cached = await cache.match(probeCacheKey(appSlug))
+    if (!cached) return null
+    const value = await cached.text()
+    if (value === 'exists') return true
+    if (value === 'missing') return false
+    return null
+  } catch {
+    return null
+  }
+}
+
+async function writeProbeCache(cache: CacheLike | null, appSlug: string, exists: boolean): Promise<void> {
+  if (!cache) return
+
+  try {
+    await cache.put(
+      probeCacheKey(appSlug),
+      new Response(exists ? 'exists' : 'missing', {
+        headers: {
+          'Cache-Control': `public, max-age=${
+            exists ? DENO2_POSITIVE_CACHE_SECONDS : DENO2_NEGATIVE_CACHE_SECONDS
+          }`,
+        },
+      }),
+    )
+  } catch {}
+}
+
+function probeCacheKey(appSlug: string): Request {
+  return new Request(`https://router.ubq.fi/__deno2_route_probe_cache__/${appSlug}`)
+}
+
+function getDefaultCache(): CacheLike | null {
+  try {
+    if (typeof caches === 'undefined') return null
+    return (caches as unknown as { default?: CacheLike }).default ?? null
+  } catch {
+    return null
   }
 }

--- a/src/utils/build-deno-url.ts
+++ b/src/utils/build-deno-url.ts
@@ -83,7 +83,7 @@ async function deno2DeploymentExists(
   options: ResolveDenoUrlOptions,
 ): Promise<ProbeResult> {
   const appSlug = buildDeno2AppSlug(subdomain)
-  const cache = options.cache ?? getDefaultCache()
+  const cache = 'cache' in options ? options.cache ?? null : getDefaultCache()
   const cached = await readProbeCache(cache, appSlug)
   if (cached !== null) return cached
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,12 +1,22 @@
 /**
  * UBQ.FI Router — Cloudflare Worker
  * Deterministic routing to Deno Deploy apps; /rpc is same‑origin proxy.
- * No KV, no discovery, no sticky cookies, no Pages fallback.
+ * Service routes prefer Deno Deploy and fall back to Deploy Classic only when
+ * the Deno platform reports the new deployment is missing.
+ * No KV, no sticky cookies, no Pages fallback.
  */
 
 import { getSubdomainKey } from './utils/get-subdomain-key'
 import { isPluginDomain } from './utils/is-plugin-domain'
-import { buildDenoUrl } from './utils/build-deno-url'
+import {
+  DENO_CLASSIC_FALLBACK_WARNING,
+  DENO_CLASSIC_MIGRATION_URL,
+  DENO_CLASSIC_SUNSET_DATE,
+  DENO_CLASSIC_SUNSET_HTTP_DATE,
+  type DenoRouteTarget,
+  isDenoDeploymentNotFound,
+  resolveDenoUrl,
+} from './utils/build-deno-url'
 import { buildPluginUrl } from './utils/build-plugin-url'
 
 export interface Env {
@@ -71,15 +81,21 @@ export default {
     const inHost = url.hostname
     const isPlugin = isPluginDomain(inHost)
     const subKey = getSubdomainKey(inHost)
-    const target = isPlugin
-      ? buildPluginUrl(inHost, url)
-      : subKey.startsWith('preview-')
-        ? buildPreviewUrl(subKey, url)
-        : buildDenoUrl(subKey, url)
+    let denoTarget: DenoRouteTarget | null = null
+    let target: string
+    if (isPlugin) {
+      target = buildPluginUrl(inHost, url)
+    } else if (subKey.startsWith('preview-')) {
+      target = buildPreviewUrl(subKey, url)
+    } else {
+      denoTarget = await resolveDenoUrl(subKey, url)
+      target = denoTarget.url
+    }
 
     const started = Date.now()
     try {
       const res = await proxy(request, target)
+      const response = handleDenoClassicFallbackResponse(res, inHost, denoTarget)
       if (shouldLog('route', request, url, env)) {
         try {
           const log = {
@@ -92,7 +108,9 @@ export default {
             hasQuery: url.search.length > 0,
             target,
             targetHost: new URL(target).hostname,
-            status: res.status,
+            denoRouteKind: denoTarget?.kind,
+            denoFallbackReason: denoTarget?.fallbackReason,
+            status: response.status,
             ms: Date.now() - started,
             workIncoming: inHost === 'work.ubq.fi',
             workTarget: !isPlugin && subKey === 'work',
@@ -102,7 +120,7 @@ export default {
           console.log(JSON.stringify({ event: 'route', ...log }))
         } catch {}
       }
-      return res
+      return response
     } catch (err) {
       console.error(JSON.stringify({
         event: 'route_error',
@@ -113,6 +131,8 @@ export default {
         hostHeader: request.headers.get('host') || undefined,
         path: url.pathname,
         target,
+        denoRouteKind: denoTarget?.kind,
+        denoFallbackReason: denoTarget?.fallbackReason,
         message: err instanceof Error ? err.message : String(err)
       }))
       return new Response('Upstream error', { status: 502 })
@@ -204,6 +224,59 @@ async function proxy(request: Request, targetUrl: string, timeoutMs = 6000): Pro
   }
   const res = await fetch(new Request(targetUrl, init), { signal: AbortSignal.timeout(timeoutMs) })
   return new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers })
+}
+
+function handleDenoClassicFallbackResponse(res: Response, inHost: string, denoTarget: DenoRouteTarget | null): Response {
+  if (denoTarget?.kind !== 'classic') return res
+
+  if (isDenoDeploymentNotFound(res.headers)) {
+    try {
+      void res.body?.cancel()
+    } catch {}
+    return denoClassicUnavailableResponse(inHost, denoTarget, res.status)
+  }
+
+  return withDenoClassicFallbackHeaders(res, denoTarget)
+}
+
+function withDenoClassicFallbackHeaders(res: Response, denoTarget: DenoRouteTarget): Response {
+  const headers = new Headers(res.headers)
+  setDenoClassicFallbackHeaders(headers, denoTarget)
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers })
+}
+
+function denoClassicUnavailableResponse(inHost: string, denoTarget: DenoRouteTarget, upstreamStatus: number): Response {
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+  })
+  setDenoClassicFallbackHeaders(headers, denoTarget)
+
+  return new Response(JSON.stringify({
+    error: {
+      message:
+        `No Deno Deploy app was found for ${inHost}, and the Deno Deploy Classic fallback is unavailable. ` +
+        `Deno Deploy Classic shuts down on ${DENO_CLASSIC_SUNSET_DATE}; migrate this service to Deno Deploy.`,
+      code: 'deno_classic_fallback_unavailable',
+      classic_sunset_date: DENO_CLASSIC_SUNSET_DATE,
+      migration_url: DENO_CLASSIC_MIGRATION_URL,
+      deno2_target: denoTarget.deno2Url,
+      classic_target: denoTarget.classicUrl,
+      upstream_status: upstreamStatus,
+    },
+  }), { status: 503, headers })
+}
+
+function setDenoClassicFallbackHeaders(headers: Headers, denoTarget: DenoRouteTarget): void {
+  headers.set('Deprecation', 'true')
+  headers.set('Sunset', DENO_CLASSIC_SUNSET_HTTP_DATE)
+  headers.set('Warning', `299 ubq.fi-router "${DENO_CLASSIC_FALLBACK_WARNING}"`)
+  headers.append('Link', `<${DENO_CLASSIC_MIGRATION_URL}>; rel="deprecation"; type="text/html"`)
+  headers.set('X-UOS-Deno-Classic-Fallback', 'true')
+  headers.set('X-UOS-Deno-Classic-Sunset', DENO_CLASSIC_SUNSET_DATE)
+  headers.set('X-UOS-Deno-Classic-Reason', denoTarget.fallbackReason ?? 'unknown')
+  headers.set('X-UOS-Deno2-Target', denoTarget.deno2Url)
+  headers.set('X-UOS-Deno-Classic-Target', denoTarget.classicUrl)
 }
 
 function buildPreviewUrl(subKey: string, url: URL): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -240,6 +240,34 @@ async function proxyRoute(
   denoTarget: DenoRouteTarget | null,
 ): Promise<RouteProxyResult> {
   const res = await proxy(request, target)
+  if (denoTarget?.kind === 'deno2' && isDenoDeploymentNotFound(res.headers)) {
+    try {
+      void res.body?.cancel()
+    } catch {}
+
+    const fallbackTarget = buildClassicFallbackTarget(denoTarget, 'deno2_deployment_not_found')
+    const classicRes = await proxy(request, fallbackTarget.classicUrl)
+    if (!isDenoDeploymentNotFound(classicRes.headers)) {
+      return {
+        response: withDenoClassicFallbackHeaders(classicRes, fallbackTarget),
+        target: fallbackTarget.classicUrl,
+        denoRouteKind: fallbackTarget.kind,
+        denoFallbackReason: fallbackTarget.fallbackReason,
+      }
+    }
+
+    try {
+      void classicRes.body?.cancel()
+    } catch {}
+
+    return {
+      response: denoClassicUnavailableResponse(inHost, fallbackTarget, classicRes.status),
+      target: fallbackTarget.classicUrl,
+      denoRouteKind: fallbackTarget.kind,
+      denoFallbackReason: fallbackTarget.fallbackReason,
+    }
+  }
+
   if (denoTarget?.kind !== 'classic') {
     return {
       response: res,
@@ -283,6 +311,19 @@ async function proxyRoute(
     target,
     denoRouteKind: denoTarget.kind,
     denoFallbackReason: denoTarget.fallbackReason,
+  }
+}
+
+function buildClassicFallbackTarget(
+  denoTarget: DenoRouteTarget,
+  fallbackReason: NonNullable<DenoRouteTarget['fallbackReason']>,
+): DenoRouteTarget {
+  return {
+    url: denoTarget.classicUrl,
+    kind: 'classic',
+    deno2Url: denoTarget.deno2Url,
+    classicUrl: denoTarget.classicUrl,
+    fallbackReason,
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -94,8 +94,8 @@ export default {
 
     const started = Date.now()
     try {
-      const res = await proxy(request, target)
-      const response = handleDenoClassicFallbackResponse(res, inHost, denoTarget)
+      const result = await proxyRoute(request, target, inHost, denoTarget)
+      const response = result.response
       if (shouldLog('route', request, url, env)) {
         try {
           const log = {
@@ -106,10 +106,10 @@ export default {
             hostHeader: request.headers.get('host') || undefined,
             path: url.pathname,
             hasQuery: url.search.length > 0,
-            target,
-            targetHost: new URL(target).hostname,
-            denoRouteKind: denoTarget?.kind,
-            denoFallbackReason: denoTarget?.fallbackReason,
+            target: result.target,
+            targetHost: new URL(result.target).hostname,
+            denoRouteKind: result.denoRouteKind,
+            denoFallbackReason: result.denoFallbackReason,
             status: response.status,
             ms: Date.now() - started,
             workIncoming: inHost === 'work.ubq.fi',
@@ -226,17 +226,64 @@ async function proxy(request: Request, targetUrl: string, timeoutMs = 6000): Pro
   return new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers })
 }
 
-function handleDenoClassicFallbackResponse(res: Response, inHost: string, denoTarget: DenoRouteTarget | null): Response {
-  if (denoTarget?.kind !== 'classic') return res
+type RouteProxyResult = Readonly<{
+  response: Response
+  target: string
+  denoRouteKind?: DenoRouteTarget['kind']
+  denoFallbackReason?: DenoRouteTarget['fallbackReason']
+}>
+
+async function proxyRoute(
+  request: Request,
+  target: string,
+  inHost: string,
+  denoTarget: DenoRouteTarget | null,
+): Promise<RouteProxyResult> {
+  const res = await proxy(request, target)
+  if (denoTarget?.kind !== 'classic') {
+    return {
+      response: res,
+      target,
+      denoRouteKind: denoTarget?.kind,
+      denoFallbackReason: denoTarget?.fallbackReason,
+    }
+  }
 
   if (isDenoDeploymentNotFound(res.headers)) {
     try {
       void res.body?.cancel()
     } catch {}
-    return denoClassicUnavailableResponse(inHost, denoTarget, res.status)
+
+    if (denoTarget.fallbackReason === 'deno2_probe_failed') {
+      const retryRes = await proxy(request, denoTarget.deno2Url)
+      if (!isDenoDeploymentNotFound(retryRes.headers)) {
+        return {
+          response: retryRes,
+          target: denoTarget.deno2Url,
+          denoRouteKind: 'deno2',
+          denoFallbackReason: denoTarget.fallbackReason,
+        }
+      }
+
+      try {
+        void retryRes.body?.cancel()
+      } catch {}
+    }
+
+    return {
+      response: denoClassicUnavailableResponse(inHost, denoTarget, res.status),
+      target,
+      denoRouteKind: denoTarget.kind,
+      denoFallbackReason: denoTarget.fallbackReason,
+    }
   }
 
-  return withDenoClassicFallbackHeaders(res, denoTarget)
+  return {
+    response: withDenoClassicFallbackHeaders(res, denoTarget),
+    target,
+    denoRouteKind: denoTarget.kind,
+    denoFallbackReason: denoTarget.fallbackReason,
+  }
 }
 
 function withDenoClassicFallbackHeaders(res: Response, denoTarget: DenoRouteTarget): Response {

--- a/tests/build-deno-url.test.ts
+++ b/tests/build-deno-url.test.ts
@@ -69,6 +69,37 @@ describe('Deno service routing', () => {
     expect(route.url).toBe('https://work-ubq-fi.deno.dev/')
   })
 
+  test('honors explicit null cache override', async () => {
+    const globalWithCaches = globalThis as unknown as { caches?: unknown }
+    const previousCaches = globalWithCaches.caches
+    globalWithCaches.caches = {
+      default: {
+        match: async () => new Response('exists'),
+        put: async () => {},
+      },
+    }
+
+    try {
+      const route = await resolveDenoUrl('pay', new URL('https://pay.ubq.fi/api/health'), {
+        cache: null,
+        fetch: async () =>
+          new Response(null, {
+            status: 404,
+            headers: { 'x-deno-error': '{"code":"DEPLOYMENT_NOT_FOUND"}' },
+          }),
+      })
+
+      expect(route.kind).toBe('classic')
+      expect(route.url).toBe('https://pay-ubq-fi.deno.dev/api/health')
+    } finally {
+      if (previousCaches === undefined) {
+        delete globalWithCaches.caches
+      } else {
+        globalWithCaches.caches = previousCaches
+      }
+    }
+  })
+
   test('detects Deno platform missing-deployment responses', () => {
     expect(isDenoDeploymentNotFound(new Headers())).toBe(false)
     expect(isDenoDeploymentNotFound(new Headers({ 'x-deno-error': '{"code":"DEPLOYMENT_NOT_FOUND"}' }))).toBe(true)

--- a/tests/build-deno-url.test.ts
+++ b/tests/build-deno-url.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildClassicDenoUrl,
+  buildDeno2Url,
+  isDenoDeploymentNotFound,
+  resolveDenoUrl,
+} from '../src/utils/build-deno-url'
+
+describe('Deno service routing', () => {
+  test('builds Deno 2 service URLs with preserved path and query', () => {
+    const url = new URL('https://ai.ubq.fi/v1/models?limit=1')
+    expect(buildDeno2Url('ai', url)).toBe('https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models?limit=1')
+  })
+
+  test('keeps root and other services compatible with classic Deno Deploy URL shape', () => {
+    expect(buildClassicDenoUrl('', new URL('https://ubq.fi/docs'))).toBe('https://ubq-fi.deno.dev/docs')
+    expect(buildClassicDenoUrl('pay', new URL('https://pay.ubq.fi/api/health'))).toBe(
+      'https://pay-ubq-fi.deno.dev/api/health',
+    )
+  })
+
+  test('routes to Deno 2 when the probe does not return a platform missing-deployment error', async () => {
+    const url = new URL('https://ai.ubq.fi/v1/models?limit=1')
+    const route = await resolveDenoUrl('ai', url, {
+      cache: null,
+      fetch: async (input, init) => {
+        expect(String(input)).toBe('https://ai-ubq-fi.ubiquity-dao.deno.net/__ubq_route_probe__')
+        expect(init?.method).toBe('HEAD')
+        return new Response(null, { status: 404 })
+      },
+    })
+
+    expect(route.kind).toBe('deno2')
+    expect(route.url).toBe('https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models?limit=1')
+  })
+
+  test('falls back to classic only when Deno 2 platform says the deployment is missing', async () => {
+    const url = new URL('https://pay.ubq.fi/api/health')
+    const route = await resolveDenoUrl('pay', url, {
+      cache: null,
+      fetch: async () =>
+        new Response(null, {
+          status: 404,
+          headers: {
+            'x-deno-error': JSON.stringify({
+              code: 'DEPLOYMENT_NOT_FOUND',
+              message: 'The requested deployment was not found.',
+            }),
+          },
+        }),
+    })
+
+    expect(route.kind).toBe('classic')
+    expect(route.fallbackReason).toBe('deno2_deployment_not_found')
+    expect(route.url).toBe('https://pay-ubq-fi.deno.dev/api/health')
+  })
+
+  test('falls back to classic when the Deno 2 probe fails', async () => {
+    const url = new URL('https://work.ubq.fi/')
+    const route = await resolveDenoUrl('work', url, {
+      cache: null,
+      fetch: async () => {
+        throw new Error('network timeout')
+      },
+    })
+
+    expect(route.kind).toBe('classic')
+    expect(route.fallbackReason).toBe('deno2_probe_failed')
+    expect(route.url).toBe('https://work-ubq-fi.deno.dev/')
+  })
+
+  test('detects Deno platform missing-deployment responses', () => {
+    expect(isDenoDeploymentNotFound(new Headers())).toBe(false)
+    expect(isDenoDeploymentNotFound(new Headers({ 'x-deno-error': '{"code":"DEPLOYMENT_NOT_FOUND"}' }))).toBe(true)
+  })
+})

--- a/tests/build-deno-url.test.ts
+++ b/tests/build-deno-url.test.ts
@@ -14,8 +14,8 @@ describe('Deno service routing', () => {
 
   test('keeps root and other services compatible with classic Deno Deploy URL shape', () => {
     expect(buildClassicDenoUrl('', new URL('https://ubq.fi/docs'))).toBe('https://ubq-fi.deno.dev/docs')
-    expect(buildClassicDenoUrl('pay', new URL('https://pay.ubq.fi/api/health'))).toBe(
-      'https://pay-ubq-fi.deno.dev/api/health',
+    expect(buildClassicDenoUrl('fixture', new URL('https://fixture.ubq.fi/__route_fixture__/resource?via=test'))).toBe(
+      'https://fixture-ubq-fi.deno.dev/__route_fixture__/resource?via=test',
     )
   })
 
@@ -35,8 +35,8 @@ describe('Deno service routing', () => {
   })
 
   test('falls back to classic only when Deno 2 platform says the deployment is missing', async () => {
-    const url = new URL('https://pay.ubq.fi/api/health')
-    const route = await resolveDenoUrl('pay', url, {
+    const url = new URL('https://fixture.ubq.fi/__route_fixture__/resource?via=test')
+    const route = await resolveDenoUrl('fixture', url, {
       cache: null,
       fetch: async () =>
         new Response(null, {
@@ -52,7 +52,7 @@ describe('Deno service routing', () => {
 
     expect(route.kind).toBe('classic')
     expect(route.fallbackReason).toBe('deno2_deployment_not_found')
-    expect(route.url).toBe('https://pay-ubq-fi.deno.dev/api/health')
+    expect(route.url).toBe('https://fixture-ubq-fi.deno.dev/__route_fixture__/resource?via=test')
   })
 
   test('falls back to classic when the Deno 2 probe fails', async () => {
@@ -80,7 +80,7 @@ describe('Deno service routing', () => {
     }
 
     try {
-      const route = await resolveDenoUrl('pay', new URL('https://pay.ubq.fi/api/health'), {
+      const route = await resolveDenoUrl('fixture', new URL('https://fixture.ubq.fi/__route_fixture__/resource'), {
         cache: null,
         fetch: async () =>
           new Response(null, {
@@ -90,7 +90,7 @@ describe('Deno service routing', () => {
       })
 
       expect(route.kind).toBe('classic')
-      expect(route.url).toBe('https://pay-ubq-fi.deno.dev/api/health')
+      expect(route.url).toBe('https://fixture-ubq-fi.deno.dev/__route_fixture__/resource')
     } finally {
       if (previousCaches === undefined) {
         delete globalWithCaches.caches

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import worker, { type Env } from '../src/worker'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('worker Deno service routing', () => {
+  test('routes service traffic to Deno 2 when the app exists', async () => {
+    const targets: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      targets.push(req.url)
+      if (req.method === 'HEAD') return new Response(null, { status: 404 })
+      return new Response('ok', { headers: { 'x-target-host': new URL(req.url).host } })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://ai.ubq.fi/v1/models?limit=1'), {} as Env)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-target-host')).toBe('ai-ubq-fi.ubiquity-dao.deno.net')
+    expect(res.headers.get('x-uos-deno-classic-fallback')).toBe(null)
+    expect(targets).toEqual([
+      'https://ai-ubq-fi.ubiquity-dao.deno.net/__ubq_route_probe__',
+      'https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models?limit=1',
+    ])
+  })
+
+  test('falls back to Deploy Classic with sunset headers when Deno 2 is missing', async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      if (req.method === 'HEAD') {
+        return new Response(null, {
+          status: 404,
+          headers: { 'x-deno-error': '{"code":"DEPLOYMENT_NOT_FOUND"}' },
+        })
+      }
+      return new Response('classic ok', { headers: { 'x-target-host': new URL(req.url).host } })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/api/health'), {} as Env)
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('classic ok')
+    expect(res.headers.get('x-target-host')).toBe('pay-ubq-fi.deno.dev')
+    expect(res.headers.get('x-uos-deno-classic-fallback')).toBe('true')
+    expect(res.headers.get('x-uos-deno-classic-sunset')).toBe('2026-07-20')
+    expect(res.headers.get('sunset')).toBe('Mon, 20 Jul 2026 00:00:00 GMT')
+  })
+
+  test('returns explanatory 503 when both Deno 2 and Deploy Classic are missing', async () => {
+    globalThis.fetch = (async () =>
+      new Response(null, {
+        status: 404,
+        headers: { 'x-deno-error': '{"code":"DEPLOYMENT_NOT_FOUND"}' },
+      })) as unknown as typeof fetch
+
+    const res = await worker.fetch(new Request('https://missing.ubq.fi/'), {} as Env)
+    const body = await res.json() as { error?: { code?: string; classic_sunset_date?: string } }
+
+    expect(res.status).toBe(503)
+    expect(res.headers.get('x-uos-deno-classic-fallback')).toBe('true')
+    expect(body.error?.code).toBe('deno_classic_fallback_unavailable')
+    expect(body.error?.classic_sunset_date).toBe('2026-07-20')
+  })
+})

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -65,4 +65,34 @@ describe('worker Deno service routing', () => {
     expect(body.error?.code).toBe('deno_classic_fallback_unavailable')
     expect(body.error?.classic_sunset_date).toBe('2026-07-20')
   })
+
+  test('retries Deno 2 request when probe fails and Deploy Classic is missing', async () => {
+    const targets: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      targets.push(req.url)
+
+      if (req.method === 'HEAD') {
+        throw new Error('probe timeout')
+      }
+      if (req.url === 'https://ai-ubq-fi.deno.dev/v1/models') {
+        return new Response(null, {
+          status: 404,
+          headers: { 'x-deno-error': '{"code":"DEPLOYMENT_NOT_FOUND"}' },
+        })
+      }
+      return new Response('deno2 ok', { headers: { 'x-target-host': new URL(req.url).host } })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://ai.ubq.fi/v1/models'), {} as Env)
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('deno2 ok')
+    expect(res.headers.get('x-target-host')).toBe('ai-ubq-fi.ubiquity-dao.deno.net')
+    expect(targets).toEqual([
+      'https://ai-ubq-fi.ubiquity-dao.deno.net/__ubq_route_probe__',
+      'https://ai-ubq-fi.deno.dev/v1/models',
+      'https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models',
+    ])
+  })
 })

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -95,4 +95,36 @@ describe('worker Deno service routing', () => {
       'https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models',
     ])
   })
+
+  test('falls back to Deploy Classic when cached-positive Deno 2 request is missing', async () => {
+    const targets: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      targets.push(req.url)
+
+      if (req.method === 'HEAD') {
+        return new Response(null, { status: 404 })
+      }
+      if (req.url === 'https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models') {
+        return new Response(null, {
+          status: 404,
+          headers: { 'x-deno-error': '{"code":"DEPLOYMENT_NOT_FOUND"}' },
+        })
+      }
+      return new Response('classic ok', { headers: { 'x-target-host': new URL(req.url).host } })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://ai.ubq.fi/v1/models'), {} as Env)
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('classic ok')
+    expect(res.headers.get('x-target-host')).toBe('ai-ubq-fi.deno.dev')
+    expect(res.headers.get('x-uos-deno-classic-fallback')).toBe('true')
+    expect(res.headers.get('x-uos-deno-classic-reason')).toBe('deno2_deployment_not_found')
+    expect(targets).toEqual([
+      'https://ai-ubq-fi.ubiquity-dao.deno.net/__ubq_route_probe__',
+      'https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models',
+      'https://ai-ubq-fi.deno.dev/v1/models',
+    ])
+  })
 })

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -40,11 +40,11 @@ describe('worker Deno service routing', () => {
       return new Response('classic ok', { headers: { 'x-target-host': new URL(req.url).host } })
     }) as typeof fetch
 
-    const res = await worker.fetch(new Request('https://pay.ubq.fi/api/health'), {} as Env)
+    const res = await worker.fetch(new Request('https://fixture.ubq.fi/__route_fixture__/resource'), {} as Env)
 
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('classic ok')
-    expect(res.headers.get('x-target-host')).toBe('pay-ubq-fi.deno.dev')
+    expect(res.headers.get('x-target-host')).toBe('fixture-ubq-fi.deno.dev')
     expect(res.headers.get('x-uos-deno-classic-fallback')).toBe('true')
     expect(res.headers.get('x-uos-deno-classic-sunset')).toBe('2026-07-20')
     expect(res.headers.get('sunset')).toBe('Mon, 20 Jul 2026 00:00:00 GMT')


### PR DESCRIPTION
## Summary
- route service subdomains through Deno Deploy first, with Deploy Classic fallback only when Deno returns DEPLOYMENT_NOT_FOUND
- add Deploy Classic sunset/deprecation headers and explanatory 503 responses when both targets are missing
- add Bun tests covering Deno 2 routing, Classic fallback, probe failures, and sunset messaging

## Why
Deno Deploy Classic shuts down on July 20, 2026. The router should prefer migrated Deno 2 apps automatically while still keeping unmigrated services working and visibly warning clients when Classic fallback is in use.

## Validation
- bun run type-check
- bun run test
- bun run build

## Notes
This PR intentionally leaves plugin and preview routing on their existing Classic mappings until their Deno 2 slug scheme is defined.