### PR TITLE
feat: append router revision footer to html responses

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -16,6 +16,7 @@ import { buildPluginUrl } from './utils/build-plugin-url'
 declare const __UOS_ROUTER_REVISION__: string | undefined
 
 const ROUTER_REVISION_HEADER = 'x-uos-router-revision'
+const ROUTER_REPOSITORY_URL = 'https://github.com/ubiquity/ubq.fi-router'
 const ROUTER_REVISION =
   typeof __UOS_ROUTER_REVISION__ === 'string' && __UOS_ROUTER_REVISION__.length > 0
     ? __UOS_ROUTER_REVISION__
@@ -121,7 +122,7 @@ export default {
           console.log(JSON.stringify({ event: 'route', ...log }))
         } catch {}
       }
-      return response
+      return await appendRevisionFooter(response)
     } catch (err) {
       console.error(JSON.stringify({
         event: 'route_error',
@@ -138,6 +139,37 @@ export default {
       return withRouterRevision(new Response('Upstream error', { status: 502 }))
     }
   }
+}
+
+function buildRevisionHref(): string {
+  if (ROUTER_REVISION === 'local') return ROUTER_REPOSITORY_URL
+  return `${ROUTER_REPOSITORY_URL}/commit/${encodeURIComponent(ROUTER_REVISION)}`
+}
+
+function revisionLabel(): string {
+  return ROUTER_REVISION.length > 12 ? ROUTER_REVISION.slice(0, 12) : ROUTER_REVISION
+}
+
+function shouldAppendRevisionFooter(response: Response): boolean {
+  const contentType = response.headers.get('content-type')?.toLowerCase() || ''
+  return response.status === 200 && contentType.includes('text/html')
+}
+
+async function appendRevisionFooter(response: Response): Promise<Response> {
+  if (!shouldAppendRevisionFooter(response)) return response
+
+  const html = await response.text()
+  const footer = `<a class="uos-revision-footer" href="${buildRevisionHref()}" target="_blank" rel="noopener noreferrer" aria-label="Router revision ${revisionLabel()}">${revisionLabel()}</a><style>.uos-revision-footer{position:fixed;right:12px;bottom:12px;z-index:2147483647;padding:4px 7px;border-radius:6px;background:rgba(17,24,39,.86);color:#fff;font:12px/1.2 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;text-decoration:none;box-shadow:0 2px 8px rgba(0,0,0,.22)}.uos-revision-footer:hover{background:rgba(17,24,39,.96);text-decoration:underline}</style>`
+  const body = /<\/body>/i.test(html)
+    ? html.replace(/<\/body>/i, `${footer}</body>`)
+    : `${html}${footer}`
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }
 
 function withRouterRevision(response: Response): Response {

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -60,3 +60,36 @@ describe('worker Deno service routing', () => {
     expect(targets).toEqual(['https://p-pay-ubq-fi.deno.dev/path?x=1'])
   })
 })
+
+
+describe('revision footer injection', () => {
+  test('appends the router revision footer to proxied HTML responses', async () => {
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => new Response('<html><body><main>ok</main></body></html>', {
+      headers: { 'content-type': 'text/html; charset=utf-8', 'content-length': '41' },
+    })) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/'), {} as Env)
+    const html = await res.text()
+
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(res.headers.get('content-length')).toBe(null)
+    expect(html).toContain('<main>ok</main>')
+    expect(html).toContain('class="uos-revision-footer"')
+    expect(html).toContain('https://github.com/ubiquity/ubq.fi-router')
+    expect(html).toContain('local</a>')
+    expect(html).toContain('</body></html>')
+  })
+
+  test('does not append the revision footer to non-HTML responses', async () => {
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({ ok: true }), {
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/api'), {} as Env)
+    const body = await res.text()
+
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(body).toBe('{"ok":true}')
+    expect(body).not.toContain('uos-revision-footer')
+  })
+})


### PR DESCRIPTION
## Summary
- append a fixed-position revision footer to proxied HTML app responses
- link the footer revision to this router repository, or to the deployed commit when `__UOS_ROUTER_REVISION__` is available
- skip non-HTML responses and remove stale `content-length` after injection
- add coverage for HTML injection and JSON passthrough behavior

## Validation
- `npm run type-check`
- `git diff --check`

Resolves #6
/claim #6