### PR TITLE
Add health dashboard route

### DIFF
--- a/src/health-dashboard.ts
+++ b/src/health-dashboard.ts
@@ -1,0 +1,292 @@
+import { getSubdomainKey } from './utils/get-subdomain-key'
+import { isPluginDomain } from './utils/is-plugin-domain'
+import { buildPluginUrl } from './utils/build-plugin-url'
+import { resolveDenoUrl } from './utils/build-deno-url'
+
+export interface HealthEnv {
+  HEALTH_SERVICE_HOSTS?: string
+  HEALTH_PLUGIN_HOSTS?: string
+  HEALTH_TIMEOUT_MS?: string
+}
+
+type HealthTargetKind = 'service' | 'plugin'
+
+type HealthTarget = Readonly<{
+  kind: HealthTargetKind
+  host: string
+  url: string
+}>
+
+type HealthCheck = Readonly<{
+  kind: HealthTargetKind
+  host: string
+  url: string
+  ok: boolean
+  status?: number
+  ms: number
+  error?: string
+}>
+
+const HEALTH_HOST = 'health.ubq.fi'
+
+const DEFAULT_SERVICE_HOSTS = [
+  'ubq.fi',
+  'work.ubq.fi',
+  'pay.ubq.fi',
+  'dao.ubq.fi',
+]
+
+const DEFAULT_PLUGIN_HOSTS = [
+  'os-command-start-stop.ubq.fi',
+  'os-command-wallet.ubq.fi',
+  'os-command-ask.ubq.fi',
+]
+
+export function isHealthDashboardHost(hostname: string): boolean {
+  return hostname === HEALTH_HOST
+}
+
+export async function handleHealthDashboard(request: Request, env: HealthEnv): Promise<Response> {
+  const url = new URL(request.url)
+  const checks = await collectHealthChecks(env)
+
+  if (url.pathname === '/api/health' || url.pathname === '/__health/checks') {
+    return json({
+      status: checks.every((check) => check.ok) ? 'ok' : 'degraded',
+      generated: new Date().toISOString(),
+      checks,
+    })
+  }
+
+  return new Response(renderDashboard(checks), {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+async function collectHealthChecks(env: HealthEnv): Promise<HealthCheck[]> {
+  const targets = await getHealthTargets(env)
+  return Promise.all(targets.map((target) => probeTarget(target, env)))
+}
+
+async function getHealthTargets(env: HealthEnv): Promise<HealthTarget[]> {
+  const serviceHosts = parseHosts(env.HEALTH_SERVICE_HOSTS, DEFAULT_SERVICE_HOSTS)
+  const pluginHosts = parseHosts(env.HEALTH_PLUGIN_HOSTS, DEFAULT_PLUGIN_HOSTS)
+
+  const serviceTargets = await Promise.all(
+    serviceHosts.map(async (host) => {
+      const targetUrl = new URL(`https://${host}/`)
+      const subdomain = getSubdomainKey(host)
+      const target = await resolveDenoUrl(subdomain, targetUrl)
+      return { kind: 'service' as const, host, url: target.url }
+    }),
+  )
+
+  const pluginTargets = pluginHosts
+    .filter((host) => isPluginDomain(host))
+    .map((host) => {
+      const targetUrl = new URL(`https://${host}/`)
+      return { kind: 'plugin' as const, host, url: buildPluginUrl(host, targetUrl) }
+    })
+
+  return [...serviceTargets, ...pluginTargets]
+}
+
+function parseHosts(value: string | undefined, fallback: string[]): string[] {
+  const raw = value?.trim()
+  if (!raw) return fallback
+
+  return raw
+    .split(/[,\s]+/)
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+async function probeTarget(target: HealthTarget, env: HealthEnv): Promise<HealthCheck> {
+  const timeout = parseTimeout(env.HEALTH_TIMEOUT_MS)
+  const started = Date.now()
+  try {
+    const response = await fetch(target.url, {
+      method: 'GET',
+      redirect: 'manual',
+      signal: AbortSignal.timeout(timeout),
+    })
+    return {
+      kind: target.kind,
+      host: target.host,
+      url: target.url,
+      ok: response.status < 500,
+      status: response.status,
+      ms: Date.now() - started,
+    }
+  } catch (err) {
+    return {
+      kind: target.kind,
+      host: target.host,
+      url: target.url,
+      ok: false,
+      ms: Date.now() - started,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function parseTimeout(value: string | undefined): number {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 4000
+  return Math.min(10000, Math.max(500, n))
+}
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj, null, 2), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+function renderDashboard(checks: HealthCheck[]): string {
+  const generated = new Date().toISOString()
+  const okCount = checks.filter((check) => check.ok).length
+  const status = okCount === checks.length ? 'Operational' : 'Degraded'
+  const rows = checks.map(renderCheckRow).join('')
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>UBQ.FI Health</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0b1020;
+      color: #eef2ff;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: linear-gradient(180deg, #111827 0%, #030712 100%);
+    }
+    main {
+      width: min(960px, calc(100vw - 32px));
+      margin: 0 auto;
+      padding: 48px 0;
+    }
+    header {
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      align-items: flex-end;
+      margin-bottom: 28px;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 32px;
+      line-height: 1.1;
+    }
+    p {
+      margin: 0;
+      color: #a5b4fc;
+    }
+    .badge {
+      border: 1px solid ${okCount === checks.length ? '#22c55e' : '#f59e0b'};
+      color: ${okCount === checks.length ? '#86efac' : '#fcd34d'};
+      border-radius: 999px;
+      padding: 8px 12px;
+      font-size: 14px;
+      white-space: nowrap;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border: 1px solid #1f2937;
+      border-radius: 8px;
+      background: rgba(15, 23, 42, 0.82);
+    }
+    th, td {
+      padding: 14px 16px;
+      border-bottom: 1px solid #1f2937;
+      text-align: left;
+      font-size: 14px;
+    }
+    th {
+      color: #c7d2fe;
+      font-weight: 600;
+      background: #111827;
+    }
+    tr:last-child td {
+      border-bottom: 0;
+    }
+    .state {
+      font-weight: 700;
+      color: #86efac;
+    }
+    .state.bad {
+      color: #fca5a5;
+    }
+    code {
+      color: #dbeafe;
+      word-break: break-all;
+    }
+    footer {
+      margin-top: 18px;
+      color: #94a3b8;
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>UBQ.FI Health</h1>
+        <p>Live probes for routed apps and plugins.</p>
+      </div>
+      <div class="badge">${escapeHtml(status)}: ${okCount}/${checks.length}</div>
+    </header>
+    <table>
+      <thead>
+        <tr>
+          <th>Status</th>
+          <th>Type</th>
+          <th>Host</th>
+          <th>Upstream</th>
+          <th>Latency</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <footer>Generated ${escapeHtml(generated)}. JSON: <code>/api/health</code></footer>
+  </main>
+</body>
+</html>`
+}
+
+function renderCheckRow(check: HealthCheck): string {
+  const status = check.ok ? 'OK' : 'DOWN'
+  const statusClass = check.ok ? 'state' : 'state bad'
+  const detail = check.status ? String(check.status) : check.error || 'error'
+  return `<tr>
+    <td><span class="${statusClass}">${status}</span> ${escapeHtml(detail)}</td>
+    <td>${escapeHtml(check.kind)}</td>
+    <td>${escapeHtml(check.host)}</td>
+    <td><code>${escapeHtml(check.url)}</code></td>
+    <td>${check.ms}ms</td>
+  </tr>`
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,11 @@ import {
   resolveDenoUrl,
 } from './utils/build-deno-url'
 import { buildPluginUrl } from './utils/build-plugin-url'
+import {
+  handleHealthDashboard,
+  isHealthDashboardHost,
+  type HealthEnv,
+} from './health-dashboard'
 
 declare const __UOS_ROUTER_REVISION__: string | undefined
 
@@ -21,7 +26,7 @@ const ROUTER_REVISION =
     ? __UOS_ROUTER_REVISION__
     : 'local'
 
-export interface Env {
+export interface Env extends HealthEnv {
   // Optional env vars to control logging without code changes
   LOG_ROUTE_SAMPLE?: string // 0..1 sampling for normal route logs (deno/plugin)
   LOG_RPC_SAMPLE?: string   // 0..1 sampling for RPC logs
@@ -74,6 +79,10 @@ export default {
         } catch {}
       }
       return withRouterRevision(json({ status: 'ok', time: new Date().toISOString() }))
+    }
+
+    if (isHealthDashboardHost(url.hostname)) {
+      return withRouterRevision(await handleHealthDashboard(request, env))
     }
 
     if (url.pathname.startsWith('/rpc/')) {

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -60,3 +60,63 @@ describe('worker Deno service routing', () => {
     expect(targets).toEqual(['https://p-pay-ubq-fi.deno.dev/path?x=1'])
   })
 })
+
+describe('health dashboard routing', () => {
+  test('serves health.ubq.fi from the router instead of proxying it as a service', async () => {
+    const targets: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      targets.push(req.url)
+      return new Response('ok')
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://health.ubq.fi/'), {
+      HEALTH_SERVICE_HOSTS: 'pay.ubq.fi',
+      HEALTH_PLUGIN_HOSTS: 'os-command-wallet.ubq.fi',
+    } as Env)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(await res.text()).toContain('UBQ.FI Health')
+    expect(targets).toEqual([
+      'https://pay-ubq-fi.ubiquity-dao.deno.net/',
+      'https://command-wallet-main.deno.dev/',
+    ])
+  })
+
+  test('exposes machine-readable health checks', async () => {
+    globalThis.fetch = (async () => new Response(null, { status: 204 })) as unknown as typeof fetch
+
+    const res = await worker.fetch(new Request('https://health.ubq.fi/api/health'), {
+      HEALTH_SERVICE_HOSTS: 'pay.ubq.fi',
+      HEALTH_PLUGIN_HOSTS: 'os-command-wallet.ubq.fi',
+      HEALTH_TIMEOUT_MS: '1000',
+    } as Env)
+    const body = await res.json() as {
+      status: string
+      checks: Array<{ kind: string; host: string; url: string; ok: boolean; status: number; ms: number }>
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.status).toBe('ok')
+    expect(body.checks).toEqual([
+      {
+        kind: 'service',
+        host: 'pay.ubq.fi',
+        url: 'https://pay-ubq-fi.ubiquity-dao.deno.net/',
+        ok: true,
+        status: 204,
+        ms: expect.any(Number),
+      },
+      {
+        kind: 'plugin',
+        host: 'os-command-wallet.ubq.fi',
+        url: 'https://command-wallet-main.deno.dev/',
+        ok: true,
+        status: 204,
+        ms: expect.any(Number),
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add a first-party `health.ubq.fi` dashboard route to the Worker router
- probe configured app and plugin hosts against their resolved upstream Deno URLs
- expose both an HTML dashboard and machine-readable `/api/health` plus `/__health/checks` JSON
- allow deployments to override checked targets and probe timeout with env vars
- cover the route and JSON API with Bun tests

## Validation
- `npm run type-check`
- `npx bun test`
- `git diff --check`

Resolves #3
/claim #3
