### PR TITLE
[codex] extend ai router timeout

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,6 +20,8 @@ const ROUTER_REVISION =
   typeof __UOS_ROUTER_REVISION__ === 'string' && __UOS_ROUTER_REVISION__.length > 0
     ? __UOS_ROUTER_REVISION__
     : 'local'
+const DEFAULT_PROXY_TIMEOUT_MS = 30_000
+const AI_PROXY_TIMEOUT_MS = 120_000
 
 export interface Env {
   // Optional env vars to control logging without code changes
@@ -220,7 +222,13 @@ async function handleRpc(request: Request, url: URL, env: Env): Promise<Response
   return withRouterRevision(new Response(resp.body, { status: resp.status, statusText: resp.statusText, headers: outHeaders }))
 }
 
-async function proxy(request: Request, targetUrl: string, timeoutMs = 6000): Promise<Response> {
+export function proxyTimeoutMsForSubdomain(subKey: string): number {
+  return subKey === 'ai' || subKey === 'preview-ai'
+    ? AI_PROXY_TIMEOUT_MS
+    : DEFAULT_PROXY_TIMEOUT_MS
+}
+
+async function proxy(request: Request, targetUrl: string, timeoutMs: number): Promise<Response> {
   const headers = new Headers()
   for (const [key, value] of request.headers.entries()) {
     const k = key.toLowerCase()
@@ -247,7 +255,8 @@ async function proxyRoute(
   target: string,
   denoTarget: DenoRouteTarget | null,
 ): Promise<RouteProxyResult> {
-  const res = await proxy(request, target)
+  const subKey = getSubdomainKey(new URL(request.url).hostname)
+  const res = await proxy(request, target, proxyTimeoutMsForSubdomain(subKey))
   return {
     response: res,
     target,

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import worker, { type Env } from '../src/worker'
+import worker, { proxyTimeoutMsForSubdomain, type Env } from '../src/worker'
 
 const originalFetch = globalThis.fetch
 
@@ -8,6 +8,12 @@ afterEach(() => {
 })
 
 describe('worker Deno service routing', () => {
+  test('gives ai service routes enough time for long model requests', () => {
+    expect(proxyTimeoutMsForSubdomain('ai')).toBe(120_000)
+    expect(proxyTimeoutMsForSubdomain('preview-ai')).toBe(120_000)
+    expect(proxyTimeoutMsForSubdomain('pay')).toBe(30_000)
+  })
+
   test('routes service traffic directly to Deno 2', async () => {
     const targets: string[] = []
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

Extends the Cloudflare router timeout for `ai.ubq.fi` service routes so long-running model requests can complete through the custom domain.

## Root Cause

`ai.ubq.fi` is served through `ubq.fi-router`, not directly by the Deno Deploy app. The router proxied service traffic with a hardcoded 6 second timeout, then returned `502 Upstream error` on timeout. Direct calls to `https://ai-ubq-fi.ubiquity-dao.deno.net` bypassed that router and succeeded for OCR requests taking 8-13 seconds.

## Changes

- Adds explicit router timeout constants.
- Gives `ai` and `preview-ai` service routes a 120 second proxy timeout.
- Uses a 30 second default for other service routes.
- Adds test coverage for the timeout policy.

## Validation

- `bun install --frozen-lockfile --no-progress`
- `bun run type-check`
- `bun test`
