### PR TITLE
feat: append revision hash footer to HTML responses

### DIFF
--- a/src/utils/revision-footer.ts
+++ b/src/utils/revision-footer.ts
@@ -1,0 +1,72 @@
+export type RevisionFooterOptions = Readonly<{
+  revision: string
+  repositoryUrl: string
+}>
+
+const FOOTER_ID = 'uos-router-revision-footer'
+const GIT_REVISION_LINK_RE =
+  /<a\b[^>]*\bid=(["'])git-revision\1[^>]*>[\s\S]*?<\/a>/i
+
+export function repositoryUrlForHost(hostname: string): string {
+  const host = hostname.toLowerCase()
+  if (host === 'ubq.fi' || host === 'www.ubq.fi') {
+    return 'https://github.com/ubiquity/ubq.fi'
+  }
+
+  const subdomain = host.endsWith('.ubq.fi')
+    ? host.slice(0, -'.ubq.fi'.length)
+    : host
+  const appName = subdomain.startsWith('preview-')
+    ? subdomain.slice('preview-'.length)
+    : subdomain
+
+  return `https://github.com/ubiquity/${appName}.ubq.fi`
+}
+
+export function decorateHtmlWithRevision(
+  html: string,
+  { revision, repositoryUrl }: RevisionFooterOptions,
+): string {
+  const shortRevision = shortRevisionHash(revision)
+  const revisionHref = revision === 'local'
+    ? repositoryUrl
+    : `${repositoryUrl}/commit/${encodeURIComponent(revision)}`
+  const revisionLink = `<a id="git-revision" href="${escapeHtml(revisionHref)}" target="_blank" rel="noopener noreferrer">${escapeHtml(shortRevision)}</a>`
+
+  if (GIT_REVISION_LINK_RE.test(html)) {
+    return html.replace(GIT_REVISION_LINK_RE, revisionLink)
+  }
+
+  const footer = [
+    `<div id="${FOOTER_ID}">`,
+    revisionLink,
+    '</div>',
+    '<style>',
+    `#${FOOTER_ID}{position:fixed;right:4px;bottom:4px;z-index:2147483647}`,
+    `#${FOOTER_ID} a{text-align:center;text-transform:uppercase;letter-spacing:2px;text-rendering:geometricPrecision;font:700 10px/1.2 monospace;color:#fff;text-decoration:none;opacity:.75;display:inline-block;text-shadow:0 1px 2px #000}`,
+    `#${FOOTER_ID} a:hover{opacity:1}`,
+    '</style>',
+  ].join('')
+
+  if (/<\/body>/i.test(html)) {
+    return html.replace(/<\/body>/i, `${footer}</body>`)
+  }
+
+  return `${html}${footer}`
+}
+
+export function isHtmlResponse(headers: Headers): boolean {
+  return headers.get('content-type')?.toLowerCase().includes('text/html') === true
+}
+
+function shortRevisionHash(revision: string): string {
+  return revision === 'local' ? revision : revision.slice(0, 7)
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,11 @@ import {
   resolveDenoUrl,
 } from './utils/build-deno-url'
 import { buildPluginUrl } from './utils/build-plugin-url'
+import {
+  decorateHtmlWithRevision,
+  isHtmlResponse,
+  repositoryUrlForHost,
+} from './utils/revision-footer'
 
 declare const __UOS_ROUTER_REVISION__: string | undefined
 
@@ -241,7 +246,32 @@ async function proxy(request: Request, targetUrl: string, timeoutMs: number): Pr
     init.body = request.clone().body
   }
   const res = await fetch(new Request(targetUrl, init), { signal: AbortSignal.timeout(timeoutMs) })
-  return withRouterRevision(new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers }))
+  return decorateResponseWithRevision(request, res)
+}
+
+async function decorateResponseWithRevision(request: Request, response: Response): Promise<Response> {
+  if (!isHtmlResponse(response.headers)) {
+    return withRouterRevision(new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    }))
+  }
+
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  const html = await response.text()
+  const repositoryUrl = repositoryUrlForHost(new URL(request.url).hostname)
+  const decoratedHtml = decorateHtmlWithRevision(html, {
+    revision: ROUTER_REVISION,
+    repositoryUrl,
+  })
+
+  return withRouterRevision(new Response(decoratedHtml, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  }))
 }
 
 type RouteProxyResult = Readonly<{

--- a/tests/revision-footer.test.ts
+++ b/tests/revision-footer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  decorateHtmlWithRevision,
+  repositoryUrlForHost,
+} from '../src/utils/revision-footer'
+
+describe('revision footer decoration', () => {
+  test('updates an existing git revision link', () => {
+    const html = '<body><div id="bottom-right"><a href="#" id="git-revision" target="_blank">unknown</a></div></body>'
+
+    const decorated = decorateHtmlWithRevision(html, {
+      revision: '91bebfb78f2b7c1e319cf6d3ee229c6426665a6b',
+      repositoryUrl: 'https://github.com/ubiquity/work.ubq.fi',
+    })
+
+    expect(decorated).toContain('https://github.com/ubiquity/work.ubq.fi/commit/91bebfb78f2b7c1e319cf6d3ee229c6426665a6b')
+    expect(decorated).toContain('>91bebfb<')
+    expect(decorated).not.toContain('unknown')
+    expect(decorated).not.toContain('uos-router-revision-footer')
+  })
+
+  test('appends a styled footer when the app has no git revision link', () => {
+    const decorated = decorateHtmlWithRevision('<html><body><main>ok</main></body></html>', {
+      revision: 'abcdef1234567890',
+      repositoryUrl: 'https://github.com/ubiquity/pay.ubq.fi',
+    })
+
+    expect(decorated).toContain('id="uos-router-revision-footer"')
+    expect(decorated).toContain('https://github.com/ubiquity/pay.ubq.fi/commit/abcdef1234567890')
+    expect(decorated).toContain('>abcdef1<')
+    expect(decorated.indexOf('uos-router-revision-footer')).toBeLessThan(decorated.indexOf('</body>'))
+  })
+
+  test('derives app repository URLs from ubq.fi hostnames', () => {
+    expect(repositoryUrlForHost('work.ubq.fi')).toBe('https://github.com/ubiquity/work.ubq.fi')
+    expect(repositoryUrlForHost('preview-pay.ubq.fi')).toBe('https://github.com/ubiquity/pay.ubq.fi')
+    expect(repositoryUrlForHost('ubq.fi')).toBe('https://github.com/ubiquity/ubq.fi')
+  })
+})


### PR DESCRIPTION
## Summary

- reuse the existing deployed `__UOS_ROUTER_REVISION__` value for app revision display
- update an existing `#git-revision` footer link when proxied HTML already provides one
- append a lightweight bottom-right revision footer for HTML apps that do not expose `#git-revision`
- derive the linked app repository from the incoming `*.ubq.fi` hostname

Resolves #6

## Verification

- `npx tsc --noEmit`
- `npx bun test`
- `git diff --check`
- `npx bun run build`
