### PR TITLE
feat: append revision footer to app pages

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,6 +20,7 @@ const ROUTER_REVISION =
   typeof __UOS_ROUTER_REVISION__ === 'string' && __UOS_ROUTER_REVISION__.length > 0
     ? __UOS_ROUTER_REVISION__
     : 'local'
+const ROUTER_REPO_URL = 'https://github.com/ubiquity/ubq.fi-router'
 const DEFAULT_PROXY_TIMEOUT_MS = 30_000
 const AI_PROXY_TIMEOUT_MS = 120_000
 
@@ -241,7 +242,38 @@ async function proxy(request: Request, targetUrl: string, timeoutMs: number): Pr
     init.body = request.clone().body
   }
   const res = await fetch(new Request(targetUrl, init), { signal: AbortSignal.timeout(timeoutMs) })
-  return withRouterRevision(new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers }))
+  const response = new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers })
+  return withRouterRevision(await withRevisionFooter(response, request))
+}
+
+async function withRevisionFooter(response: Response, request: Request): Promise<Response> {
+  if (request.method === 'HEAD') return response
+  if (response.status < 200 || response.status >= 300) return response
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
+  if (!contentType.includes('text/html')) return response
+
+  const html = await response.text()
+  const footer = renderRevisionFooter()
+  const bodyCloseTag = /<\/body\s*>/i
+  const updatedHtml = bodyCloseTag.test(html)
+    ? html.replace(bodyCloseTag, `${footer}</body>`)
+    : `${html}${footer}`
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  return new Response(updatedHtml, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+function renderRevisionFooter(): string {
+  const revision = ROUTER_REVISION.trim() || 'local'
+  const shortRevision = revision === 'local' ? revision : revision.slice(0, 7)
+  const href = revision === 'local'
+    ? ROUTER_REPO_URL
+    : `${ROUTER_REPO_URL}/commit/${encodeURIComponent(revision)}`
+  return `<div id="uos-router-revision"><a href="${href}" target="_blank" rel="noopener noreferrer" aria-label="Router revision ${shortRevision}">${shortRevision}</a></div><style>#uos-router-revision{position:fixed;right:18px;bottom:14px;z-index:2147483647;font:12px/1.2 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;letter-spacing:.04em;text-transform:uppercase;opacity:.35;transition:opacity .15s ease}#uos-router-revision:hover{opacity:1}#uos-router-revision a{color:inherit;text-decoration:none}#uos-router-revision a:hover{text-decoration:underline}@media(max-width:640px){#uos-router-revision{display:none}}</style>`
 }
 
 type RouteProxyResult = Readonly<{

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -28,6 +28,7 @@ describe('worker Deno service routing', () => {
     expect(res.headers.get('x-uos-router-revision')).toBe('local')
     expect(res.headers.get('x-target-host')).toBe('ai-ubq-fi.ubiquity-dao.deno.net')
     expect(res.headers.get('x-uos-deno-classic-fallback')).toBe(null)
+    expect(await res.text()).toBe('ok')
     expect(targets).toEqual(['https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models?limit=1'])
   })
 
@@ -64,5 +65,39 @@ describe('worker Deno service routing', () => {
     expect(await res.text()).toBe('preview ok')
     expect(res.headers.get('x-target-host')).toBe('p-pay-ubq-fi.deno.dev')
     expect(targets).toEqual(['https://p-pay-ubq-fi.deno.dev/path?x=1'])
+  })
+
+  test('appends the router revision footer to successful HTML app responses', async () => {
+    globalThis.fetch = (async () => new Response('<html><body><main>app</main></body></html>', {
+      headers: {
+        'content-length': '42',
+        'content-type': 'text/html; charset=utf-8',
+      },
+    })) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/'), {} as Env)
+    const html = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(res.headers.get('content-length')).toBe(null)
+    expect(html).toContain('<main>app</main>')
+    expect(html).toContain('id="uos-router-revision"')
+    expect(html).toContain('https://github.com/ubiquity/ubq.fi-router')
+    expect(html).toContain('>local</a>')
+  })
+
+  test('does not append the router revision footer to non-HTML responses', async () => {
+    globalThis.fetch = (async () => new Response('{"ok":true}', {
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/api/status'), {} as Env)
+    const body = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(body).toBe('{"ok":true}')
+    expect(body).not.toContain('uos-router-revision')
   })
 })


### PR DESCRIPTION
## Summary
- Appends a small fixed-position router revision footer to successful proxied HTML app responses
- Links the displayed revision to the `ubiquity/ubq.fi-router` commit when a deployed SHA is available, with a `local` fallback for development
- Leaves non-HTML responses unchanged and removes stale `content-length` after HTML injection
- Adds routing tests for HTML footer injection and non-HTML passthrough

## Validation
- Static diff reviewed
- Could not run `bun test` locally because `bun` is not installed in this runner and npm dependency install timed out; CI should run the repository's Bun test workflow

Resolves #6