### PR TITLE
Add dynamic sitemap and plugin map endpoints

### DIFF
--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -1,0 +1,165 @@
+import type { JsonPluginMap, PluginMapEntry } from './types'
+
+const GENERATOR = 'ubq-fi-router'
+const DEFAULT_CHANGEFREQ = 'daily'
+const DEFAULT_LASTMOD = '2026-01-01'
+
+export type SitemapApp = Readonly<{
+  host: string
+  priority?: number
+  changefreq?: 'daily' | 'weekly' | 'monthly'
+  lastmod?: string
+}>
+
+export type SitemapPlugin = Readonly<{
+  host: string
+  pluginName: string
+  displayName: string
+  description?: string
+  repo: string
+  priority?: number
+  changefreq?: 'daily' | 'weekly' | 'monthly'
+  lastmod?: string
+}>
+
+export type SitemapEntry = Readonly<{
+  loc: string
+  lastmod: string
+  changefreq: 'daily' | 'weekly' | 'monthly'
+  priority: number
+}>
+
+export type JsonSitemap = Readonly<{
+  version: string
+  generated: string
+  generator: string
+  total: number
+  urls: SitemapEntry[]
+}>
+
+const DEFAULT_APPS: SitemapApp[] = [
+  { host: 'ubq.fi', priority: 1 },
+  { host: 'www.ubq.fi', priority: 0.9 },
+  { host: 'pay.ubq.fi', priority: 0.9 },
+  { host: 'work.ubq.fi', priority: 0.9 },
+  { host: 'dao.ubq.fi', priority: 0.8 },
+  { host: 'rpc.ubq.fi', priority: 0.7 },
+]
+
+const DEFAULT_PLUGINS: SitemapPlugin[] = [
+  {
+    host: 'os-command-config.ubq.fi',
+    pluginName: 'command-config-main',
+    displayName: 'Command Config',
+    description: 'Command configuration plugin.',
+    repo: 'ubiquity-os-marketplace/command-config',
+    priority: 0.6,
+  },
+  {
+    host: 'os-command-start-stop.ubq.fi',
+    pluginName: 'command-start-stop-main',
+    displayName: 'Command Start Stop',
+    description: 'Start and stop command plugin.',
+    repo: 'ubiquity-os-marketplace/command-start-stop',
+    priority: 0.6,
+  },
+]
+
+export function buildSitemapEntries(apps = DEFAULT_APPS, plugins = DEFAULT_PLUGINS): SitemapEntry[] {
+  return [...apps.map(appToEntry), ...plugins.map(pluginToEntry)].sort((a, b) => a.loc.localeCompare(b.loc))
+}
+
+export function buildJsonSitemap(generated = new Date().toISOString()): JsonSitemap {
+  const urls = buildSitemapEntries()
+  return {
+    version: '1',
+    generated,
+    generator: GENERATOR,
+    total: urls.length,
+    urls,
+  }
+}
+
+export function buildJsonPluginMap(generated = new Date().toISOString()): JsonPluginMap {
+  const plugins = DEFAULT_PLUGINS.map((plugin) => pluginToMapEntry(plugin))
+  return {
+    version: '1',
+    generated,
+    generator: GENERATOR,
+    totalPlugins: plugins.length,
+    plugins,
+  }
+}
+
+export function renderSitemapXml(entries = buildSitemapEntries()): string {
+  const urls = entries
+    .map(
+      (entry) => `  <url>
+    <loc>${escapeXml(entry.loc)}</loc>
+    <lastmod>${escapeXml(entry.lastmod)}</lastmod>
+    <changefreq>${entry.changefreq}</changefreq>
+    <priority>${entry.priority.toFixed(1)}</priority>
+  </url>`
+    )
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`
+}
+
+function appToEntry(app: SitemapApp): SitemapEntry {
+  return {
+    loc: `https://${app.host}/`,
+    lastmod: app.lastmod ?? DEFAULT_LASTMOD,
+    changefreq: app.changefreq ?? DEFAULT_CHANGEFREQ,
+    priority: app.priority ?? 0.8,
+  }
+}
+
+function pluginToEntry(plugin: SitemapPlugin): SitemapEntry {
+  return {
+    loc: `https://${plugin.host}/`,
+    lastmod: plugin.lastmod ?? DEFAULT_LASTMOD,
+    changefreq: plugin.changefreq ?? 'weekly',
+    priority: plugin.priority ?? 0.6,
+  }
+}
+
+function pluginToMapEntry(plugin: SitemapPlugin): PluginMapEntry {
+  return {
+    url: `https://${plugin.host}/`,
+    pluginName: plugin.pluginName,
+    displayName: plugin.displayName,
+    description: plugin.description ?? '',
+    serviceType: 'plugin-deno',
+    deployments: {
+      main: {
+        available: true,
+        url: `https://${plugin.pluginName}.deno.dev`,
+      },
+      development: {
+        available: true,
+        url: `https://${plugin.pluginName.replace(/-main$/, '-development')}.deno.dev`,
+      },
+    },
+    github: {
+      repo: plugin.repo,
+      url: `https://github.com/${plugin.repo}`,
+    },
+    priority: plugin.priority ?? 0.6,
+    changefreq: plugin.changefreq ?? 'weekly',
+    lastmod: plugin.lastmod ?? DEFAULT_LASTMOD,
+  }
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,7 @@ import {
   resolveDenoUrl,
 } from './utils/build-deno-url'
 import { buildPluginUrl } from './utils/build-plugin-url'
+import { buildJsonPluginMap, buildJsonSitemap, renderSitemapXml } from './sitemap'
 
 declare const __UOS_ROUTER_REVISION__: string | undefined
 
@@ -76,6 +77,23 @@ export default {
         } catch {}
       }
       return withRouterRevision(json({ status: 'ok', time: new Date().toISOString() }))
+    }
+
+    if (url.pathname === '/sitemap.xml') {
+      return withRouterRevision(new Response(renderSitemapXml(), {
+        headers: {
+          'Content-Type': 'application/xml; charset=utf-8',
+          'Cache-Control': 'public, max-age=300',
+        },
+      }))
+    }
+
+    if (url.pathname === '/sitemap.json') {
+      return withRouterRevision(json(buildJsonSitemap()))
+    }
+
+    if (url.pathname === '/plugins.json') {
+      return withRouterRevision(json(buildJsonPluginMap()))
     }
 
     if (url.pathname.startsWith('/rpc/')) {

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+import worker, { type Env } from '../src/worker'
+import { buildJsonPluginMap, buildJsonSitemap, buildSitemapEntries, renderSitemapXml } from '../src/sitemap'
+
+describe('dynamic sitemap generation', () => {
+  test('builds sitemap entries for apps and plugins', () => {
+    const entries = buildSitemapEntries()
+
+    expect(entries.some((entry) => entry.loc === 'https://ubq.fi/')).toBe(true)
+    expect(entries.some((entry) => entry.loc === 'https://pay.ubq.fi/')).toBe(true)
+    expect(entries.some((entry) => entry.loc === 'https://os-command-config.ubq.fi/')).toBe(true)
+  })
+
+  test('renders XML sitemap with expected metadata', () => {
+    const xml = renderSitemapXml([
+      {
+        loc: 'https://pay.ubq.fi/',
+        lastmod: '2026-01-01',
+        changefreq: 'daily',
+        priority: 0.9,
+      },
+    ])
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(xml).toContain('<loc>https://pay.ubq.fi/</loc>')
+    expect(xml).toContain('<priority>0.9</priority>')
+  })
+
+  test('builds JSON sitemap and plugin map', () => {
+    const sitemap = buildJsonSitemap('2026-01-01T00:00:00.000Z')
+    const pluginMap = buildJsonPluginMap('2026-01-01T00:00:00.000Z')
+
+    expect(sitemap.total).toBe(sitemap.urls.length)
+    expect(pluginMap.totalPlugins).toBe(pluginMap.plugins.length)
+    expect(pluginMap.plugins[0].deployments.main.url).toContain('deno.dev')
+  })
+
+  test('serves sitemap and plugin map endpoints before proxy routing', async () => {
+    const xml = await worker.fetch(new Request('https://ubq.fi/sitemap.xml'), {} as Env)
+    const json = await worker.fetch(new Request('https://ubq.fi/sitemap.json'), {} as Env)
+    const plugins = await worker.fetch(new Request('https://ubq.fi/plugins.json'), {} as Env)
+
+    expect(xml.headers.get('content-type')).toContain('application/xml')
+    expect(await xml.text()).toContain('<urlset')
+    expect((await json.json()).total).toBeGreaterThan(0)
+    expect((await plugins.json()).totalPlugins).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Closes ubiquity/ubq.fi-router#2

## Summary

Adds deterministic sitemap and plugin map generation for UBQ.FI apps and plugins.

## What changed

- Added `src/sitemap.ts` with JSON sitemap, plugin map, and XML rendering helpers.
- Added Worker endpoints: `/sitemap.xml`, `/sitemap.json`, and `/plugins.json`.
- Added tests covering app/plugin entries, XML rendering, JSON structures, and Worker routing before proxy fallback.

## Notes

The implementation is local-config driven and keeps the router's no-KV/no-discovery approach.

## Validation

Could not run `bun test` locally because `bun`, `npm`, and `tsc` are not available on PATH in this environment.