### PR TITLE
Append app revision footer

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -16,6 +16,7 @@ import { buildPluginUrl } from './utils/build-plugin-url'
 declare const __UOS_ROUTER_REVISION__: string | undefined
 
 const ROUTER_REVISION_HEADER = 'x-uos-router-revision'
+const APP_REVISION_ANCHOR_ID = 'git-revision'
 const ROUTER_REVISION =
   typeof __UOS_ROUTER_REVISION__ === 'string' && __UOS_ROUTER_REVISION__.length > 0
     ? __UOS_ROUTER_REVISION__
@@ -255,13 +256,119 @@ async function proxyRoute(
   target: string,
   denoTarget: DenoRouteTarget | null,
 ): Promise<RouteProxyResult> {
-  const subKey = getSubdomainKey(new URL(request.url).hostname)
+  const url = new URL(request.url)
+  const subKey = getSubdomainKey(url.hostname)
   const res = await proxy(request, target, proxyTimeoutMsForSubdomain(subKey))
   return {
-    response: res,
+    response: await appendRevisionFooter(res, request, target, subKey, isPluginDomain(url.hostname)),
     target,
     denoRouteKind: denoTarget?.kind,
   }
+}
+
+async function appendRevisionFooter(
+  response: Response,
+  request: Request,
+  target: string,
+  subKey: string,
+  isPlugin: boolean,
+): Promise<Response> {
+  if (request.method === 'HEAD') return response
+  if (!isHtmlResponse(response)) return response
+
+  const html = await response.text()
+  const revision = getAppRevision(response.headers, target)
+  const repoUrl = getRepoUrl(subKey, isPlugin)
+  const footer = buildRevisionFooter(revision, repoUrl, target)
+  const nextHtml = html.match(new RegExp(`id=["']${APP_REVISION_ANCHOR_ID}["']`, 'i'))
+    ? updateExistingRevisionAnchor(html, revision, repoUrl, target)
+    : injectBeforeBodyEnd(html, footer)
+
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  return new Response(nextHtml, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+function isHtmlResponse(response: Response): boolean {
+  return (response.headers.get('content-type') || '').toLowerCase().includes('text/html')
+}
+
+function getAppRevision(headers: Headers, target: string): string {
+  const explicitRevision =
+    headers.get('x-uos-app-revision') ||
+    headers.get('x-app-revision') ||
+    headers.get('x-deno-deployment-id') ||
+    headers.get('etag')
+
+  if (explicitRevision) {
+    return explicitRevision.replace(/^W\//, '').replace(/^"|"$/g, '').slice(0, 12)
+  }
+
+  return new URL(target).hostname
+}
+
+function getRepoUrl(subKey: string, isPlugin: boolean): string {
+  const name = subKey.replace(/^preview-/, '')
+  if (isPlugin) {
+    return `https://github.com/ubiquity-os-marketplace/${name}`
+  }
+  return `https://github.com/ubiquity/${name || 'ubq'}.ubq.fi`
+}
+
+function buildRevisionFooter(revision: string, repoUrl: string, target: string): string {
+  const safeRevision = escapeHtml(revision)
+  const safeRepoUrl = escapeHtml(repoUrl)
+  const safeTarget = escapeHtml(target)
+
+  return `
+<style id="uos-revision-footer-style">
+  #bottom-right { position: fixed; right: 16px; bottom: 16px; z-index: 2147483647; display: flex; gap: 8px; align-items: center; }
+  #${APP_REVISION_ANCHOR_ID} { color: inherit; opacity: 0.68; font: 12px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; text-decoration: none; }
+  #${APP_REVISION_ANCHOR_ID}:hover { opacity: 1; text-decoration: underline; }
+</style>
+<div id="bottom-right"><a href="${safeRepoUrl}" id="${APP_REVISION_ANCHOR_ID}" target="_blank" rel="noopener noreferrer" title="${safeTarget}">${safeRevision}</a></div>`
+}
+
+function updateExistingRevisionAnchor(html: string, revision: string, repoUrl: string, target: string): string {
+  const safeRevision = escapeHtml(revision)
+  const safeRepoUrl = escapeHtml(repoUrl)
+  const safeTarget = escapeHtml(target)
+
+  return html.replace(
+    /<a\b([^>]*\bid=["']git-revision["'][^>]*)>[\s\S]*?<\/a>/i,
+    (_match, attrs: string) => {
+      const nextAttrs = upsertAttribute(upsertAttribute(upsertAttribute(attrs, 'href', safeRepoUrl), 'title', safeTarget), 'rel', 'noopener noreferrer')
+      return `<a${nextAttrs}>${safeRevision}</a>`
+    },
+  )
+}
+
+function upsertAttribute(attrs: string, name: string, value: string): string {
+  const pattern = new RegExp(`\\s${name}=(["']).*?\\1`, 'i')
+  if (pattern.test(attrs)) {
+    return attrs.replace(pattern, ` ${name}="${value}"`)
+  }
+  return `${attrs} ${name}="${value}"`
+}
+
+function injectBeforeBodyEnd(html: string, fragment: string): string {
+  if (/<\/body>/i.test(html)) {
+    return html.replace(/<\/body>/i, `${fragment}</body>`)
+  }
+  return `${html}${fragment}`
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
 }
 
 function buildPreviewUrl(subKey: string, url: URL): string {

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -65,4 +65,56 @@ describe('worker Deno service routing', () => {
     expect(res.headers.get('x-target-host')).toBe('p-pay-ubq-fi.deno.dev')
     expect(targets).toEqual(['https://p-pay-ubq-fi.deno.dev/path?x=1'])
   })
+
+  test('injects revision footer into app html responses', async () => {
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response('<html><body><main>Pay</main></body></html>', {
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          etag: 'W/"abcdef1234567890"',
+        },
+      })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/'), {} as Env)
+    const html = await res.text()
+
+    expect(html).toContain('id="git-revision"')
+    expect(html).toContain('abcdef123456')
+    expect(html).toContain('href="https://github.com/ubiquity/pay.ubq.fi"')
+    expect(html).toContain('https://pay-ubq-fi.ubiquity-dao.deno.net/')
+    expect(res.headers.get('content-length')).toBe(null)
+  })
+
+  test('populates existing work-style revision anchor without duplicating it', async () => {
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response('<html><body><div id="bottom-right"><a href="#" id="git-revision" target="_blank"></a></div></body></html>', {
+        headers: {
+          'content-type': 'text/html',
+          'x-uos-app-revision': 'fedcba987654321',
+        },
+      })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://work.ubq.fi/'), {} as Env)
+    const html = await res.text()
+
+    expect(html.match(/id="git-revision"/g)?.length).toBe(1)
+    expect(html).toContain('fedcba987654')
+    expect(html).toContain('href="https://github.com/ubiquity/work.ubq.fi"')
+  })
+
+  test('does not inject revision footer into non-html responses', async () => {
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/api'), {} as Env)
+    const body = await res.text()
+
+    expect(body).toBe(JSON.stringify({ ok: true }))
+    expect(body).not.toContain('git-revision')
+  })
 })


### PR DESCRIPTION
Closes #6.

Adds a router-side revision footer for HTML app responses, matching the existing `#bottom-right` / `#git-revision` shape from work.ubq.fi.

- injects a revision link for app HTML responses
- populates existing `#git-revision` anchors without duplicating them
- links derived app/plugin repos for faster debugging
- leaves non-HTML responses untouched

Validation:
- `tsc --noEmit`
- `bun test`