### PR TITLE
fix: append router revision link to HTML footers

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,6 +20,7 @@ const ROUTER_REVISION =
   typeof __UOS_ROUTER_REVISION__ === 'string' && __UOS_ROUTER_REVISION__.length > 0
     ? __UOS_ROUTER_REVISION__
     : 'local'
+const ROUTER_REPOSITORY_URL = 'https://github.com/ubiquity/ubq.fi-router'
 const DEFAULT_PROXY_TIMEOUT_MS = 30_000
 const AI_PROXY_TIMEOUT_MS = 120_000
 
@@ -152,6 +153,69 @@ function withRouterRevision(response: Response): Response {
   })
 }
 
+async function withFooterRevision(response: Response): Promise<Response> {
+  const contentType = response.headers.get('content-type') || ''
+  if (!/\btext\/html\b/i.test(contentType)) return response
+
+  const html = await response.text()
+  const rewritten = injectFooterRevision(html)
+  const headers = new Headers(response.headers)
+  if (rewritten !== html) headers.delete('content-length')
+
+  return new Response(rewritten, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+function injectFooterRevision(html: string): string {
+  const href = revisionHref()
+  const label = `Revision ${ROUTER_REVISION}`
+  const revisionLink = `<a id="git-revision" href="${escapeHtmlAttribute(href)}" rel="noopener noreferrer" target="_blank">${escapeHtml(label)}</a>`
+
+  if (/\bid=(['"])git-revision\1/i.test(html)) {
+    return html.replace(/<a\b([^>]*\bid=(['"])git-revision\2[^>]*)>([\s\S]*?)<\/a>/gi, (match, attrs: string) => {
+      const withoutHref = attrs.replace(/\s+href=(['"])[\s\S]*?\1/i, '')
+      const normalizedAttrs = withoutHref.replace(/\s+target=(['"])[\s\S]*?\1/i, '').replace(/\s+rel=(['"])[\s\S]*?\1/i, '')
+      return `<a${normalizedAttrs} href="${escapeHtmlAttribute(href)}" rel="noopener noreferrer" target="_blank">${escapeHtml(label)}</a>`
+    })
+  }
+
+  if (/<\/footer>/i.test(html)) {
+    return html.replace(/<\/footer>/gi, `${revisionLink}</footer>`)
+  }
+
+  const revisionFooter = `<footer data-uos-router-revision="true">${revisionLink}</footer>`
+  if (/<\/body>/i.test(html)) {
+    return html.replace(/<\/body>/i, `${revisionFooter}</body>`)
+  }
+
+  return `${html}${revisionFooter}`
+}
+
+function revisionHref(): string {
+  return ROUTER_REVISION === 'local'
+    ? ROUTER_REPOSITORY_URL
+    : `${ROUTER_REPOSITORY_URL}/commit/${encodeURIComponent(ROUTER_REVISION)}`
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"]/g, (char) => {
+    switch (char) {
+      case '&': return '&amp;'
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '"': return '&quot;'
+      default: return char
+    }
+  })
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return escapeHtml(value).replace(/'/g, '&#39;')
+}
+
 function json(obj: unknown, status = 200): Response {
   return new Response(JSON.stringify(obj), {
     status,
@@ -241,7 +305,8 @@ async function proxy(request: Request, targetUrl: string, timeoutMs: number): Pr
     init.body = request.clone().body
   }
   const res = await fetch(new Request(targetUrl, init), { signal: AbortSignal.timeout(timeoutMs) })
-  return withRouterRevision(new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers }))
+  const response = new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers })
+  return withRouterRevision(await withFooterRevision(response))
 }
 
 type RouteProxyResult = Readonly<{

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -31,6 +31,79 @@ describe('worker Deno service routing', () => {
     expect(targets).toEqual(['https://ai-ubq-fi.ubiquity-dao.deno.net/v1/models?limit=1'])
   })
 
+  test('injects the router revision link into HTML footers', async () => {
+    const html = '<!doctype html><html><body><main>App</main><footer><span>UBQ</span></footer></body></html>'
+    globalThis.fetch = (async () => {
+      return new Response(html, {
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          'content-length': String(html.length),
+        },
+      })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/'), {} as Env)
+    const body = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(res.headers.get('content-length')).toBe(null)
+    expect(body).toContain('<footer><span>UBQ</span><a id="git-revision"')
+    expect(body).toContain('href="https://github.com/ubiquity/ubq.fi-router"')
+    expect(body).toContain('Revision local</a></footer>')
+  })
+
+  test('populates an existing git revision footer link', async () => {
+    globalThis.fetch = (async () => {
+      return new Response('<footer><a id="git-revision" href="#">old</a></footer>', {
+        headers: { 'content-type': 'text/html' },
+      })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/'), {} as Env)
+    const body = await res.text()
+
+    expect(body).toContain('<a id="git-revision" href="https://github.com/ubiquity/ubq.fi-router" rel="noopener noreferrer" target="_blank">Revision local</a>')
+  })
+
+  test('adds a revision footer to HTML responses without an existing footer', async () => {
+    const html = '<!doctype html><html><body><main>App without footer</main></body></html>'
+    globalThis.fetch = (async () => {
+      return new Response(html, {
+        headers: {
+          'content-type': 'text/html',
+          'content-length': String(html.length),
+        },
+      })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/no-footer'), {} as Env)
+    const body = await res.text()
+
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(res.headers.get('content-length')).toBe(null)
+    expect(body).toContain('<main>App without footer</main>')
+    expect(body).toContain('<footer data-uos-router-revision="true"><a id="git-revision"')
+    expect(body).toContain('Revision local</a></footer></body>')
+  })
+
+  test('passes non-HTML responses through without body rewrite', async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: {
+          'content-type': 'application/json',
+          'content-length': '11',
+        },
+      })
+    }) as typeof fetch
+
+    const res = await worker.fetch(new Request('https://pay.ubq.fi/api/state'), {} as Env)
+
+    expect(res.headers.get('x-uos-router-revision')).toBe('local')
+    expect(res.headers.get('content-length')).toBe('11')
+    expect(await res.text()).toBe('{"ok":true}')
+  })
+
   test('passes Deno 2 missing-deployment responses through without Classic fallback', async () => {
     const targets: string[] = []
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary
- Inject router revision links into proxied HTML footers.
- Preserve non-HTML passthrough behavior.
- Remove stale Content-Length after HTML rewrites.
## Verification
- bun run test
- bun run build
Note: bun run type-check could not run locally because `tsc` was not available in this clone.
B. Đợi maintainer duyệt