### PR TITLE
fix: extend AI stream reliability window

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -21,7 +21,7 @@ const ROUTER_REVISION =
     ? __UOS_ROUTER_REVISION__
     : 'local'
 const DEFAULT_PROXY_TIMEOUT_MS = 30_000
-const AI_PROXY_TIMEOUT_MS = 120_000
+const AI_PROXY_TIMEOUT_MS = 270_000
 
 export interface Env {
   // Optional env vars to control logging without code changes
@@ -137,6 +137,15 @@ export default {
         denoRouteKind: denoTarget?.kind,
         message: err instanceof Error ? err.message : String(err)
       }))
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        return withRouterRevision(json({
+          error: {
+            message: 'The router timed out waiting for upstream response headers.',
+            type: 'server_error',
+            code: 'router_upstream_timeout',
+          },
+        }, 504))
+      }
       return withRouterRevision(new Response('Upstream error', { status: 502 }))
     }
   }
@@ -240,7 +249,8 @@ async function proxy(request: Request, targetUrl: string, timeoutMs: number): Pr
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     init.body = request.clone().body
   }
-  const res = await fetch(new Request(targetUrl, init), { signal: AbortSignal.timeout(timeoutMs) })
+  const signal = AbortSignal.any([request.signal, AbortSignal.timeout(timeoutMs)])
+  const res = await fetch(new Request(targetUrl, init), { signal })
   return withRouterRevision(new Response(res.body, { status: res.status, statusText: res.statusText, headers: res.headers }))
 }
 

--- a/tests/worker-routing.test.ts
+++ b/tests/worker-routing.test.ts
@@ -9,8 +9,8 @@ afterEach(() => {
 
 describe('worker Deno service routing', () => {
   test('gives ai service routes enough time for long model requests', () => {
-    expect(proxyTimeoutMsForSubdomain('ai')).toBe(120_000)
-    expect(proxyTimeoutMsForSubdomain('preview-ai')).toBe(120_000)
+    expect(proxyTimeoutMsForSubdomain('ai')).toBe(270_000)
+    expect(proxyTimeoutMsForSubdomain('preview-ai')).toBe(270_000)
     expect(proxyTimeoutMsForSubdomain('pay')).toBe(30_000)
   })
 


### PR DESCRIPTION
## What changed

- raises the AI proxy deadline from 120 seconds to 270 seconds
- combines the router deadline with downstream client cancellation
- returns an OpenAI-compatible structured 504 when the router expires before upstream headers
- keeps response bodies streaming without buffering
- applies the same proxy path and timeout behavior to `ai` and `preview-ai`

## Why

Yunwu calls have taken 135–204 seconds while the router stopped waiting at 120 seconds. The gateway now owns a 240-second deadline, so the router leaves a 30-second outer margin while still terminating abandoned work when the client disconnects.

## Validation

- `bun test` (`7 passed`)
- `bun run type-check`
- `git diff --check`

## Explicitly not yet complete

This draft has not been deployed. It must land only with the separately reviewed gateway rebuild after isolated preview acceptance. Required remaining gates include exact revision and custom-domain tests, a stream-open-beyond-120-seconds fixture, 30-minute soak, rollback rehearsal, and production approval. This PR does not authorize or perform any production routing change.